### PR TITLE
fix: scope release build filter to publishable packages only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm check:prisma-next-descriptors
 
       - name: Build packages
-        run: pnpm build --filter=@prisma-next-idb/* --filter=@prisma-idb/idb-client-generator
+        run: pnpm build --filter="./packages/prisma-next/*" --filter="./packages/generator"
 
       - name: Create release PR or publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0

--- a/packages/prisma-next/docs/adrs/ADR 015 - Contract-Derived Validation.md
+++ b/packages/prisma-next/docs/adrs/ADR 015 - Contract-Derived Validation.md
@@ -1,0 +1,66 @@
+# ADR 015 — Contract-Derived Validation
+
+## Context
+
+Nothing in the current stack validates record _shape_. `decodeJsonRecord` (`target-idb/src/core/decode-json-record.ts`, added alongside `apply-pull.ts`'s atomicity fix) walks `contract.domain` and converts wire-JSON values to native JS types field-by-field — but it's a pure transform. If a field is missing, mistyped, or a malicious/buggy payload has an extra field where a relation should be, `decodeJsonRecord` doesn't notice; it decodes whatever's there and hands it to the write path.
+
+This is a live gap on both sides:
+
+- **Pull** (`apply-pull.ts`): a malformed changelog row currently either writes garbage into IDB or throws deep inside a codec/IDB call, caught by `applyLog`'s blanket `try/catch` and silently skipped — no distinction between "this was stale, ignore it" and "this was corrupt, something is wrong upstream."
+- **Push** (ADR 014's `sync-server`): a malformed outbox event must be rejected _before_ it reaches ownership-DAG resolution — validating shape and validating scope are different questions, and shape has to come first (no point computing an authorization path for a payload that doesn't even match the contract).
+
+The old generator solved this with emitted zod validators — one generated `z.object({...})` per model (`fileCreators/validators/model-validator.ts`), used at push time (`validators.${model.name}.safeParse(event.payload)`, `create.ts:355`) and for changelog `keyPath` (`keyPathValidators.${model.name}.safeParse`, `create.ts:301`). Structured errors (`RECORD_VALIDATION_FAILURE`, `KEYPATH_VALIDATION_FAILURE`) distinguish "this didn't parse" from other failure classes.
+
+## Decision
+
+### Runtime-derived arktype validators, not generated code
+
+Build a per-model validator by walking `contract.domain.models[modelName].fields` at the point a validator is first needed (lazily memoized — no reason to build validators for models never pushed/pulled) — the same "derive from contract.domain, nothing generated" posture as `decodeJsonRecord` and ADR 014's DAG construction. Use **arktype**, matching the framework's own convention (`vendor/prisma-next/CLAUDE.md`: "Use arktype, not zod") and its `paramsSchema: StandardSchemaV1` pattern already present in `CodecLookup`/`CodecDescriptor` — an arktype type satisfies `StandardSchemaV1` natively, so a validator built this way composes with anything upstream that already expects that interface, with no adapter layer.
+
+```ts
+function buildFieldValidator(field: ContractField): Type {
+  const base = SCALAR_VALIDATORS[/* resolve from field.type.codecId's targetTypes, or field.type.kind */];
+  const withNull = field.nullable ? base.or("null") : base;
+  return field.many ? withNull.array() : withNull;
+}
+
+function buildModelValidator(contract: IdbContract, modelName: string): Type<Record<string, unknown>> {
+  const model = domainModelsAtDefaultNamespace(contract.domain)[modelName];
+  const shape = Object.fromEntries(
+    Object.entries(model.fields).map(([name, field]) => [name, buildFieldValidator(field)])
+  );
+  return type(shape);
+}
+```
+
+This lives next to `decodeJsonRecord` in `target-idb/src/core/` (same package, same reason — it's contract/codec-aware, family-agnostic-callers shouldn't reimplement field-walking) and is exported alongside it (`validateRecord(contract, modelName, record): ValidationResult`).
+
+### Where it's called
+
+- **`sync-server`'s `validatePush`** (ADR 014) validates shape first, before DAG resolution — a shape failure short-circuits with `RECORD_VALIDATION_FAILURE`, never reaching the ownership check. `keyPath`/key validation is the same mechanism applied to a model's key field(s) alone, giving `KEYPATH_VALIDATION_FAILURE` as a distinct code (matches the old generator's error taxonomy — see Consequences on why the distinction is kept).
+- **`apply-pull.ts`** (client-side): validates `log.record` after `decodeJsonRecord`, before it reaches `applyLog`'s transaction. A validation failure is treated as `skipped`, not a thrown error — the client can't do anything about a corrupt changelog row except decline to apply it and keep going; that's a materially different situation from "this was already applied" but the _external contract_ (the `ApplyPullResult` shape) doesn't currently distinguish failure reasons, which is worth revisiting once this lands (see Consequences).
+
+### Not emitted, not generated, not cached to disk
+
+Every alternative that writes a file (emitted zod source, a `sync.generated.ts` module) was rejected for the reason already established across ADR 012-014: it's a second artifact that can drift from the contract it's derived from, and the framework's whole post-Phase-7 design direction is toward fewer generated files, not more (`INDEX.md`: the manifest was deleted for exactly this reason). The one-time cost of building an arktype schema at first use is negligible next to an IDB round-trip or an HTTP request.
+
+## Why arktype over zod
+
+Zod was the old generator's choice because it emits directly as readable generated TypeScript source — nobody using the old generator ever saw arktype's runtime-construction API, they saw a `.ts` file. That advantage disappears the moment validators are built at runtime instead of emitted: nothing about "emitted code should be human-readable" applies to a function that runs once and produces an in-memory `Type`. With that constraint gone, the deciding factor is consistency with the framework we're building on top of — arktype is already a first-class citizen in codec config schemas and the framework's own `CLAUDE.md` convention, and introducing zod as a second validation library into this stack for no functional reason is exactly the kind of divergence `FEEDBACK.md`'s Group A was about.
+
+## Consequences
+
+- **Two new structured error/skip reasons need surfacing**: shape validation failure (record doesn't match the contract) is categorically different from staleness (already-applied) or ownership rejection (real record, wrong pusher). `sync-server`'s `validatePush` return type should carry this distinction explicitly (mirroring `pushErrorTypes.RECORD_VALIDATION_FAILURE`/`KEYPATH_VALIDATION_FAILURE`), and `apply-pull.ts`'s `ApplyPullResult` likely needs a reason breakdown on `skipped` rather than one flat count — currently it doesn't distinguish "stale" from "pending-local-change" from anything else either, so this is a pre-existing gap this ADR makes more visible, not one it introduces.
+- **Validator construction cost is paid once per model per process lifetime** (memoized), not per record — acceptable given `sync-server` is a long-lived server process and `sync-extension-idb` is a long-lived browser session.
+- **Field-to-arktype mapping needs to cover every `idb/*` codec's `targetTypes`** (`target-idb/src/core/codecs.ts`'s nine descriptors) — `Uint8Array`/`bigint` need arktype's `instanceof`/`bigint` primitives rather than the JSON-native types `decodeJsonRecord` already converts _to_, since validation runs on the already-decoded native-JS record, not the wire form.
+- **This does not replace `decodeJsonRecord`.** Decode-then-validate is the pipeline order — validating wire-shaped JSON against native-JS-typed schemas would reject everything (an ISO string is never a valid `Date` under a schema expecting `instanceof Date`).
+
+## Related
+
+- ADR 014 — Sync Ownership DAG — the primary consumer on the push side; shape validation runs first, ahead of DAG resolution
+- ADR 012 — Client Contract Subsetting — the client contract this validates against is the _projected_ one; the server validates against the full contract
+- `target-idb/src/core/decode-json-record.ts` — sibling helper, same "derive from `contract.domain`, no generated file" posture, and the required upstream pipeline step
+- `target-idb/src/core/codecs.ts` — the nine `idb/*` codec descriptors whose `targetTypes` drive the field-to-arktype mapping
+- `packages/generator/src/fileCreators/validators/model-validator.ts`, `batch-processor/create.ts:290-343,352-370` — old generator's emitted-zod precedent and error-taxonomy precedent (`pushErrorTypes`)
+- `vendor/prisma-next/CLAUDE.md` — "Use arktype, not zod" convention
+- `vendor/.../framework-components/src/shared/codec-types.ts` — `CodecDescriptor.paramsSchema: StandardSchemaV1`, the existing arktype/StandardSchema touchpoint this ADR's validators compose with

--- a/packages/prisma-next/docs/adrs/ADR 016 - Declarative Record Transforms in IDB Migrations.md
+++ b/packages/prisma-next/docs/adrs/ADR 016 - Declarative Record Transforms in IDB Migrations.md
@@ -1,0 +1,214 @@
+# ADR 016 — Declarative Record Transforms in IDB Migrations
+
+## Status
+
+Proposed — draft, pending review.
+
+## Context
+
+`sync-extension-idb`'s `OutboxEvent.synced` field is typed `Boolean` (`src/contract.ts`) and is the `keyPath` of the `bySynced` index. `Boolean` has never been a valid IndexedDB key type — `IDBKeyRange.only(false)` throws `DataError` in every real browser, not just a `fake-indexeddb` quirk. This was fixed pragmatically by dropping the index query in favor of an in-memory `.filter((e) => !e.synced)` scan (`outbox-store.ts`), which works because `false`/`0` are both falsy — but it leaves the contract lying about the field's type for every install that ever synced before the fix, and leaves `bySynced` permanently dead: a real index that can never be queried, because you cannot construct a valid `IDBKeyRange` over a boolean.
+
+The correct type is `Int` (`0`/`1`) — `Number` has always been a valid IDB key. Making that change for real requires two things: (1) the contract's field type, and (2) rewriting the value stored in every existing record from `true`/`false` to `1`/`0`. The first is trivial. The second turned out not to be supported by anything in this framework, for reasons worth recording:
+
+- **`diffIdbSchema` (`target-idb/src/core/schema-diff.ts`) never looks at field types.** It only compares object-store `keyPath`/`autoIncrement` and index `keyPath`/`unique`/`multiEntry`, because IndexedDB stores are schemaless — there's no DDL concept of a column type to alter. Flipping `synced: "Boolean"` → `"Int"` in `src/contract.ts` with `bySynced`'s `keyPath` unchanged produces **zero** ops. `migration plan` reports "contract is unchanged since the last migration — nothing to do."
+- **`IdbDdlOp` (`target-idb/src/core/migration-factories.ts`) is a closed union of exactly four purely structural kinds** — `createObjectStore`, `dropObjectStore`, `createIndex`, `dropIndex`. `applyOneDdlOp` (`target-idb/src/core/apply-ddl-op.ts:29`) is an exhaustive `switch` over exactly those four, with no data-mutation case. A hand-invented fifth `kind` written directly into `ops.json` would silently no-op at apply time — nothing case-matches, nothing throws.
+- **The framework already has a slot for this.** Upstream `MigrationOperationClass` (`vendor/prisma-next/.../control-migration-types.ts:76`) is `'additive' | 'widening' | 'destructive' | 'data'`, with `'data'` documented as "Data transformation operation (e.g., backfill, type conversion)". `migration-plan.ts:176` already passes `"data"` into `allowedOperationClasses`. Nothing in `target-idb` has ever produced an op of that class — the door was left open, nobody walked through it.
+- **Postgres and Mongo already solve this class of problem, and neither ships a function.** `postgres/src/core/migrations/operations/data-transform.ts` and the Mongo `dataTransform()` in `mongo-target/.../migration-factories.ts` both accept what looks like an arbitrary closure at the `migration.ts` call site — but both _invoke the closure once, at author-time_, inside `node migration.ts` (a real Node process, full JS environment), and lower its return value to inert, JSON-serializable data before anything touches `ops.json`. Postgres lowers to `{sql, params}` text. Mongo lowers to a serializable update/aggregation command document (BSON, itself just JSON). In both cases the thing replayed against a real user's database is pure data, interpreted by a fixed, generic executor — never a function, never `eval`.
+- **IDB has no declarative mutation language to lower a closure into.** SQL has `UPDATE ... SET x = CASE WHEN ...`. Mongo has `$set`/`$toInt`/aggregation pipelines. Raw `cursor.update(value)` just takes a literal JS value the caller already computed — there is no IDB-native expression syntax to compile a closure down to. To follow the same "author writes ergonomic code, `ops.json` holds inert data" shape every other target in this framework already uses, IDB needs its own small declarative value-expression vocabulary — there's no existing one to borrow.
+- **Storing `fn.toString()` and `new Function(...)`-evaling it at apply time was considered and rejected.** It doesn't survive minification/bundling (`tsdown`/esbuild rename captured identifiers and can inline/dead-code-eliminate), and it requires `unsafe-eval`, which conflicts with any CSP a consuming app sets. No other target in this framework does this, for the same reasons.
+
+## Decision
+
+### A new, closed `IdbDdlOp` kind: `transformRecords`
+
+```ts
+export type IdbJsonLiteral = string | number | boolean | null;
+
+export type IdbValueTransform =
+  | { readonly kind: "coerce"; readonly to: "int" | "string" | "boolean" | "isoDateString" }
+  | { readonly kind: "defaultIfMissing"; readonly value: IdbJsonLiteral }
+  | { readonly kind: "setLiteral"; readonly value: IdbJsonLiteral }
+  | { readonly kind: "pipe"; readonly steps: readonly IdbValueTransform[] };
+
+export type TransformRecordsOp = MigrationPlanOperation & {
+  readonly kind: "transformRecords";
+  readonly storeName: string;
+  /** Per-field value transforms, keyed by field name. Applied to `record[field]`. */
+  readonly fields?: Readonly<Record<string, IdbValueTransform>>;
+  /** `{ newName: oldName }` — moves a value between keys. Applied before `fields`. */
+  readonly renameFields?: Readonly<Record<string, string>>;
+  /** Field names to delete outright. Applied after `fields`. */
+  readonly removeFields?: readonly string[];
+};
+```
+
+`fields` is deliberately a pure value→value map — every member of `IdbValueTransform` reads `record[field]` and produces its replacement, which is what makes `pipe` composable (`pipe`'s steps thread a single value through in order). `renameFields`/`removeFields` operate on the record's key-space rather than a single field's value, so they're kept as separate top-level maps instead of being forced into the same value-transform shape — trying to model "rename" as a value transform (`pipe(rename("synced"), coerce("int"))`, operating on one nominal field) produces an awkward "which field am I actually reading" ambiguity; keeping shape-changes and value-changes as two distinct phases avoids that.
+
+Per record, application order is fixed: **`renameFields` → `fields` → `removeFields`** — so a field can be renamed and then have its new name's value coerced in the same pass (see the combined example below), and a field can be transformed and then still be removed later in the same pass if it turns out to be fully deprecated.
+
+### The op vocabulary
+
+| Kind (in `fields`)   | Purpose                                                                                                          | Shape                                                                       | Example                                 |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | --------------------------------------- |
+| `coerce`             | Convert a field's stored value to a different primitive representation                                           | `{ kind: "coerce", to: "int" \| "string" \| "boolean" \| "isoDateString" }` | `coerce("int")`                         |
+| `defaultIfMissing`   | Backfill a field that's `undefined` on the stored record; leaves any existing value (including `null`) untouched | `{ kind: "defaultIfMissing", value: IdbJsonLiteral }`                       | `defaultIfMissing("member")`            |
+| `setLiteral`         | Unconditionally overwrite a field with a constant, ignoring whatever was there                                   | `{ kind: "setLiteral", value: IdbJsonLiteral }`                             | `setLiteral(0)`                         |
+| `pipe`               | Compose several value transforms into one, left to right                                                         | `{ kind: "pipe", steps: readonly IdbValueTransform[] }`                     | `pipe(coerce("string"), coerce("int"))` |
+| `renameFields` entry | Move a value from one key to another; the old key is deleted                                                     | _(op-level map, not a value transform)_ `{ [newName]: oldFieldName }`       | `renameFields: { isSynced: "synced" }`  |
+| `removeFields` entry | Delete a field outright, regardless of its value                                                                 | _(op-level list, not a value transform)_ string field name                  | `removeFields: ["legacyPhoneNumber"]`   |
+
+### `coerce` semantics, by source value
+
+| `to`              | `boolean` input     | `number` input                                        | `string` input                                                                      | `null`/`undefined` |
+| ----------------- | ------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------- | ------------------ |
+| `"int"`           | `true→1`, `false→0` | passthrough as-is                                     | `Number(value)`; **throws** if the result is `NaN`                                  | passthrough as-is  |
+| `"string"`        | `String(value)`     | `String(value)`                                       | passthrough as-is                                                                   | passthrough as-is  |
+| `"boolean"`       | passthrough as-is   | `value !== 0`                                         | exact literal match only — `"true"→true`, `"false"→false`, anything else **throws** | passthrough as-is  |
+| `"isoDateString"` | **throws**          | treated as epoch ms → `new Date(value).toISOString()` | validated via `Date.parse`; passthrough if valid, **throws** if not                 | passthrough as-is  |
+
+Unparseable/unrepresentable inputs throw rather than silently coercing to a wrong-but-plausible value (e.g. `Number("abc")` silently becoming `0`, or a loose `Boolean("false")` silently becoming `true`). This matches the existing philosophy already stated twice elsewhere in this codebase: `schema-diff.ts`'s store-mutation guard ("silent no-op is worse than an explicit error") and `apply-ddl-op.ts`'s idempotency-guard doc comment. A migration that throws mid-`upgradeneeded` aborts the whole version-change transaction — nothing partially applies (see ADR 002).
+
+`null`/`undefined` always pass through every `coerce` unchanged — compose with `defaultIfMissing` first (via `pipe`) if a field needs both a fallback and a type change.
+
+### Worked examples
+
+**The motivating bug** — `synced` needs to become a real `Int`:
+
+```ts
+// migrations/<timestamp>_synced_to_int/migration.ts
+import { Migration, MigrationCLI, transformRecordsOp, coerce } from "@prisma-next-idb/target-idb/migration";
+
+export default class M extends Migration {
+  override describe() {
+    return {
+      from: "sha256:7fde36649c356a3b6962006d44bb08e84372aa86bb23671252eab9b4cf45e798",
+      to: "sha256:<computed-on-emit>",
+    };
+  }
+
+  override get operations() {
+    return [
+      transformRecordsOp("_idb_sync_outbox", {
+        fields: { synced: coerce("int") },
+      }),
+    ];
+  }
+}
+
+MigrationCLI.run(import.meta.url, M);
+```
+
+**Field rename**, e.g. `synced` → `isSynced`:
+
+```ts
+transformRecordsOp("_idb_sync_outbox", {
+  renameFields: { isSynced: "synced" },
+});
+```
+
+**Rename and retype in the same pass** — the coerce targets the field under its _new_ name, since `renameFields` runs first:
+
+```ts
+transformRecordsOp("_idb_sync_outbox", {
+  renameFields: { isSynced: "synced" },
+  fields: { isSynced: coerce("int") },
+});
+```
+
+**Backfilling a newly-required field** on records written before the field existed:
+
+```ts
+transformRecordsOp("users", {
+  fields: { role: defaultIfMissing("member") },
+});
+```
+
+**Dropping a deprecated/sensitive field** from data already synced to the client (a local GDPR-style purge, or just cleanup after a schema change removed the field server-side):
+
+```ts
+transformRecordsOp("users", {
+  removeFields: ["legacyPhoneNumber"],
+});
+```
+
+**Force-resetting a corrupted computed/cache field**, ignoring its current value entirely:
+
+```ts
+transformRecordsOp("posts", {
+  fields: { commentCountCache: setLiteral(0) },
+});
+```
+
+### How this actually gets authored — `migration plan` never proposes it
+
+`diffIdbSchema` still never looks at field types (that's unchanged and intentionally out of scope — see "What we deliberately did not build"), so `prisma-next-idb migration plan` never emits a `transformRecords` op on its own. The full authoring flow for the motivating example:
+
+1. `src/contract.ts` — change `synced: "Boolean"` to `synced: "Int"`.
+2. `pnpm --filter @prisma-next-idb/sync-extension-idb contract:emit`.
+3. `prisma-next-idb migration plan --space idb-sync --name synced_to_int` — writes a new migration package with an **empty** `ops.json` (no structural diff), because IDB is schemaless at the field level. This step still matters: it's what advances `end-contract.json`/`storageHash` and scaffolds `migration.ts`/`migration.json` with the right `from`/`to` pair.
+4. Hand-edit that migration's `migration.ts`, adding the `transformRecordsOp(...)` call to `operations` (as above).
+5. `node migrations/<dir>/migration.ts` — the file's own self-emit CLI (`MigrationCLI.run`, `migration-cli.ts`) — re-emits `ops.json`/`migration.json` from the edited `operations` getter, now containing the real op and a recomputed content hash.
+6. Add the new migration's `{dirName, metadata, ops}` entry to the `migrations: [...]` array in `src/exports/control.ts` by hand (this is already a manual step for every incremental migration in this package today — `migration plan` prints a reminder to that effect, per `migration-plan.ts:373`).
+7. `prisma-next-idb preflight` — replays the whole chain against `fake-indexeddb`, including the new cursor-based op, to confirm it applies cleanly end to end.
+
+Because `ops.json` is unconditionally regenerated from `operations` in step 5, there is never a risk of the two files drifting (the exact class of bug `family-idb/test/generate-baseline.test.ts`'s `"migration.ts matches ops.json exactly"` test already guards against for the structural ops — the same guarantee extends here for free, since it's the same emit path).
+
+### Execution model — cursor iteration inside `upgradeneeded`, no `await`
+
+ADR 005 established that nothing may `await` between IDB request issuance inside a live transaction's event handlers — a transaction auto-commits once an event handler returns without issuing another request, and `await` yields to the microtask queue in the gap. `applyOneDdlOp`'s four existing cases are synchronous IDB calls (`db.createObjectStore`, `store.createIndex`, etc.) and return immediately; `transformRecords` is the first case that's inherently asynchronous (a cursor walk over however many records the store holds), so it has to follow the same callback-chaining pattern ADR 005 already documents for `driver-idb/src/core/execute/ops.ts`'s `runOpsSequentially()` — never a `Promise`/`await` inside the cursor's `onsuccess`.
+
+```ts
+case "transformRecords": {
+  const store = tx.objectStore(op.storeName);
+  const cursorReq = store.openCursor();
+  cursorReq.onsuccess = () => {
+    const cursor = cursorReq.result;
+    if (!cursor) {
+      onDone();
+      return;
+    }
+    cursor.update(transformOneRecord(cursor.value as Record<string, unknown>, op));
+    cursor.continue(); // issued synchronously, inside this same onsuccess — no await
+  };
+  return; // completion signaled later, via onDone() from inside the terminal onsuccess
+}
+```
+
+This forces a signature change: `applyOneDdlOp(db, tx, op)` (synchronous, `void`) becomes `applyOneDdlOp(db, tx, op, onDone: () => void)` — the four existing cases call `onDone()` synchronously at the end of their case (no behavior change), the new case calls it from the cursor's terminal `onsuccess`. Both current call sites' own `for (const op of ops) { applyOneDdlOp(db, tx, op); }` loops — `openAndUpgrade` (`apply-ddl-op.ts:214-219`) and `preflight.ts`'s `applyPackage` (`preflight.ts:128-131`) — become a recursive `runNext(i)` that only advances to `i + 1` from inside `onDone()`, mirroring the exact pattern already established for `runOpsSequentially()` rather than inventing a new one. Neither function's _own_ external signature changes (`openAndUpgrade` still returns `Promise<number>`; `applyPackage` still returns `Promise<void>`) — this is entirely internal to how they walk their op list.
+
+Errors during the cursor walk (`cursorReq.onerror`) are not separately caught — like every other IDB request in this codebase, an unhandled request error propagates to the transaction's `onerror`/`onabort`, aborting the whole `upgradeneeded` transaction. Nothing partially applies, consistent with every existing DDL op.
+
+## Consequences
+
+- **This is the first genuine data-migration capability this target has ever had.** Every future "field renamed", "field retyped", "backfill a computed default", or "drop a deprecated field from already-synced data" need reuses the same six-entry vocabulary — not a bespoke enum member per transform, which is what an earlier, narrower version of this idea (a single hardcoded `booleanToInt01` transform name) would have required for every future case.
+- **`ops.json` stays 100% inert JSON.** No function, no `fn.toString()`, no `eval`. This keeps IDB consistent with how Postgres/Mongo already handle `operationClass: "data"` in this same framework — author-time convenience, apply-time pure data.
+- **`transformRecords` is always hand-authored, never auto-generated.** `diffIdbSchema` staying field-type-blind is unchanged (and correct — see below); `migration plan` will keep emitting empty diffs for pure type/value changes. An author has to know to reach for this op; nothing prompts them to.
+- **`applyOneDdlOp`'s signature change is a breaking, internal-only change**, contained to its three known callers (`openAndUpgrade`, `preflight.ts`'s `applyPackage`, and any direct test usage) — none of which are part of any package's public API surface.
+- **A whole-store cursor walk is O(n) in that store's row count**, run synchronously (in wall-clock terms, still inside one `upgradeneeded` transaction, just spread across many `onsuccess` turns) before the version-change transaction can commit. For the stores this framework actually deals with (client-local IDB data, not a multi-million-row server table), this is a non-issue; worth flagging as a real cost if this is ever pointed at an unexpectedly large store.
+- **The vocabulary is intentionally small and closed.** It covers the concrete cases already enumerated (retype, rename, backfill, remove, force-reset) but not, e.g., computing one field from another (`fullName` from `firstName + lastName`) or cross-store transforms. Extending it further is a matter of adding another `IdbValueTransform` variant plus an `applyValueTransform` case — the same shape of change as this ADR itself, not a redesign.
+
+## What we deliberately did not build
+
+- **No expansion of `diffIdbSchema` to detect field-type changes.** IDB genuinely doesn't enforce field types at the storage layer — teaching the differ to notice a contract-level type change and _auto-propose_ a `transformRecords` op would require guessing the author's intent (is `Boolean→Int` a `coerce("int")`, or actually an unrelated field rename that happens to change type too?). That guess belongs to a human, every time. This op stays exclusively hand-authored.
+- **No `renderTypeScript()`/planner-IR integration for this op**, unlike SQL/Mongo's `OpFactoryCall` machinery. IDB's `IdbMigration.operations` already returns plain `IdbDdlOp[]` values directly (see the existing baseline `migration.ts`, which calls `createObjectStoreOp(...)` literally inline) — there's no separate "render the call as TypeScript source" step to begin with, because the author's own hand-typed source _is_ the rendering. That machinery exists for SQL/Mongo because their migrations are sometimes auto-generated from a diff; since this op is never auto-generated, there's nothing to render.
+- **No arbitrary predicate/filter on which records within a store get transformed.** Every `transformRecords` op walks the entire store. A conditional transform (e.g. "only rows where `x` is null") isn't covered by this ADR — it would need its own op or a `when` clause on `TransformRecordsOp`, deferred until a real use case shows up.
+- **No `fn.toString()`/`eval` escape hatch, not even as an opt-in "advanced" mode.** Considered and rejected outright (see Context) — it would undermine the one invariant this whole design exists to preserve.
+
+## Open questions for review
+
+- Should `transformRecords` (an `operationClass: "data"` op) be subject to any policy gate at authoring or preflight time, the way `"destructive"` ops implicitly are treated with more caution elsewhere? Right now nothing in `migration plan`'s `allowedOperationClasses` check actually applies to this op, since it's spliced into `operations` by hand _after_ planning, not produced by the planner — worth deciding whether `preflight` should require some explicit acknowledgment (e.g. a `--allow-data-ops` flag) before treating a chain containing one as valid.
+- Should `coerce`'s throwing behavior on unparseable input be configurable per-call (e.g. an optional `onInvalid: "throw" | "skip"`), or is "always throw, always abort the transaction" the right permanent default? This ADR takes the stricter position; it's easy to loosen later, hard to tighten after someone's depended on silent skipping.
+
+## Related
+
+- ADR 002 — Two-Phase Migration (the `upgradeneeded`/marker-write split `transformRecords` runs inside)
+- ADR 005 — Event-Driven Execution: No async/await Inside IDB Transactions (the constraint this op's cursor-walk implementation must follow, and the `runOpsSequentially()` pattern it mirrors)
+- ADR 008 — Two Migration Paths (Path B, the hand-authorable/git-tracked path this op is exclusively authored through)
+- ADR 011 — No Migration Materialization for IDB Extensions (`--space` authoring applies identically to a migration containing this op)
+- `target-idb/src/core/schema-diff.ts` — `diffIdbSchema`, confirmed field-type-blind by design; this ADR does not change that
+- `target-idb/src/core/apply-ddl-op.ts` — `applyOneDdlOp`, `openAndUpgrade`; both change shape per "Execution model" above
+- `family-idb/src/core/preflight.ts` — `applyPackage`; same shape change
+- `family-idb/src/core/migration-plan.ts` — `allowedOperationClasses` already includes `"data"`, previously unused
+- `vendor/prisma-next/packages/1-framework/1-core/framework-components/src/control/control-migration-types.ts` — upstream `MigrationOperationClass`, the framework-level slot this ADR finally fills for IDB
+- `vendor/prisma-next/packages/3-targets/3-targets/postgres/src/core/migrations/operations/data-transform.ts`, `packages/3-mongo-target/1-mongo-target/src/core/migration-factories.ts` — the sibling-target precedent this design's "closure lowers to inert data" shape is grounded in
+- `sync-extension-idb/src/contract.ts`, `outbox-store.ts` — `OutboxEvent.synced`, the motivating case


### PR DESCRIPTION
## Summary
- The release workflow's build filter (`--filter=@prisma-next-idb/*`) matched `apps/prisma-next-idb-kanban-example`'s package name by coincidence, pulling that private, unpublished app into the release build.
- Its `build` script now runs `contract:emit:postgres` (added by #208's sync work), which requires a live `DATABASE_URL` the release job never provisions — this broke the release run right after #208 merged.
- Switched to directory-based filters (`./packages/prisma-next/*`, `./packages/generator`) so only actually-publishable packages are ever considered, which can't accidentally catch an app again.

## Test plan
- [x] `pnpm exec turbo run build --filter="./packages/prisma-next/*" --filter="./packages/generator" --dry-run=json` resolves to exactly the 10 intended packages (9 `@prisma-next-idb/*` + the generator), no apps included
- [x] `pnpm build --filter="./packages/prisma-next/*" --filter="./packages/generator"` succeeds locally, all 10 packages build
- [ ] Release workflow succeeds on merge to `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to build the appropriate packages using workspace path filters.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->