### PR TITLE
feat: enhance mutation defaults handling and fix SQL autoincrement bug

### DIFF
--- a/.changeset/gentle-planets-sing.md
+++ b/.changeset/gentle-planets-sing.md
@@ -1,0 +1,7 @@
+---
+"@prisma-next-idb/target-idb": minor
+"@prisma-next-idb/family-idb": minor
+"@prisma-next-idb/client-idb": minor
+---
+
+Add `@default(...)` and bare `@updatedAt` support to the IDB family's PSL interpreter: literal defaults, `now()`, `uuid()`/`uuid(7)`, `cuid()`, and `autoincrement()` (mapped to IndexedDB's native auto-incrementing keys). Fields with an `onCreate` default — including `temporal.updatedAt()` from the previous release — are now correctly optional in `create()`'s input type, not just the primary key.

--- a/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/migration.json
+++ b/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/migration.json
@@ -3,5 +3,5 @@
   "to": "sha256:401b2b0687bca2ef0fab5ec851a8509b4f58b5b6cb59528e18eefa06c3a4c867",
   "providedInvariants": [],
   "createdAt": "2026-08-09T08:31:25.025Z",
-  "migrationHash": "sha256:9e13c6561d69a6916c08fc3e8f1b7a39916bc37d98681a02dd03973c74a57d9c"
+  "migrationHash": "sha256:e8f38b62dadaf274bcd3f15105760a6c00528ddf67f6b41a15041afcf4721321"
 }

--- a/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/migration.ts
+++ b/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/migration.ts
@@ -57,7 +57,7 @@ export default class M extends Migration<never, End> {
         schema: "public",
         table: "changelog",
         columns: [
-          col("id", "int4", { notNull: true, default: fn("autoincrement()") }),
+          col("id", "SERIAL", { notNull: true, default: fn("autoincrement()") }),
           col("model", "text", { notNull: true }),
           col("keyPath", "text", { notNull: true }),
           col("operation", "text", { notNull: true }),

--- a/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/ops.json
+++ b/apps/prisma-next-idb-kanban-example/migrations-postgres/app/20260809T0831_baseline/ops.json
@@ -162,7 +162,7 @@
     "execute": [
       {
         "description": "create table \"changelog\"",
-        "sql": "CREATE TABLE \"public\".\"changelog\" (\n  \"id\" int4 NOT NULL,\n  \"model\" text NOT NULL,\n  \"keyPath\" text NOT NULL,\n  \"operation\" text NOT NULL,\n  \"scopeKey\" text NOT NULL,\n  \"outboxEventId\" text NOT NULL,\n  \"createdAt\" timestamptz DEFAULT (now()) NOT NULL,\n  PRIMARY KEY (\"id\"),\n  CONSTRAINT \"changelog_outboxEventId_key\" UNIQUE (\"outboxEventId\")\n)",
+        "sql": "CREATE TABLE \"public\".\"changelog\" (\n  \"id\" SERIAL NOT NULL,\n  \"model\" text NOT NULL,\n  \"keyPath\" text NOT NULL,\n  \"operation\" text NOT NULL,\n  \"scopeKey\" text NOT NULL,\n  \"outboxEventId\" text NOT NULL,\n  \"createdAt\" timestamptz DEFAULT (now()) NOT NULL,\n  PRIMARY KEY (\"id\"),\n  CONSTRAINT \"changelog_outboxEventId_key\" UNIQUE (\"outboxEventId\")\n)",
         "params": []
       }
     ],

--- a/packages/prisma-next/client-idb/package.json
+++ b/packages/prisma-next/client-idb/package.json
@@ -36,6 +36,7 @@
     "@prisma-next-idb/target-idb": "workspace:*",
     "@prisma-next/contract": "^0.16.0",
     "@prisma-next/framework-components": "^0.16.0",
+    "@prisma-next/ids": "^0.16.0",
     "@prisma-next/migration-tools": "^0.16.0"
   },
   "devDependencies": {

--- a/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
@@ -73,7 +73,7 @@ export function applyCreateDefaults(
   let result = data;
   for (const d of defaults) {
     if (d.ref.table !== storeName || !d.onCreate) continue;
-    if (Object.hasOwn(result, d.ref.column)) continue;
+    if (result[d.ref.column] !== undefined) continue;
     if (result === data) result = { ...data };
     result[d.ref.column] = resolveGeneratedValue(d.onCreate, cache);
   }
@@ -82,9 +82,10 @@ export function applyCreateDefaults(
 
 /**
  * Fills in every column with an `onUpdate` default that `patch` doesn't
- * already set. An empty `patch` is returned unchanged — no write means no
- * default should fire either (matches SQL's "empty update payloads skip
- * onUpdate defaults" rule).
+ * already set. A patch with no defined values (empty, or every field
+ * explicitly `undefined`) is returned unchanged — no write means no default
+ * should fire either (matches SQL's "empty update payloads skip onUpdate
+ * defaults" rule).
  */
 export function applyUpdateDefaults(
   defaults: readonly ExecutionMutationDefault[] | undefined,
@@ -92,12 +93,12 @@ export function applyUpdateDefaults(
   patch: Record<string, unknown>,
   cache: MutationDefaultsCache
 ): Record<string, unknown> {
-  if (Object.keys(patch).length === 0) return patch;
+  if (Object.values(patch).every((v) => v === undefined)) return patch;
   if (!defaults || defaults.length === 0) return patch;
   let result = patch;
   for (const d of defaults) {
     if (d.ref.table !== storeName || !d.onUpdate) continue;
-    if (Object.hasOwn(result, d.ref.column)) continue;
+    if (result[d.ref.column] !== undefined) continue;
     if (result === patch) result = { ...patch };
     result[d.ref.column] = resolveGeneratedValue(d.onUpdate, cache);
   }

--- a/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
@@ -1,0 +1,85 @@
+/**
+ * Applies `contract.execution.mutations.defaults` (ADR 158) during a
+ * create/update — IDB's equivalent of the SQL family's
+ * `ExecutionContext.applyMutationDefaults`. Today the only generator id is
+ * `"timestampNow"`, backing `temporal.updatedAt()` fields.
+ *
+ * Semantics mirror the SQL reference implementation:
+ * - a caller-provided value always wins over a default;
+ * - an empty update patch skips every `onUpdate` default (no write ⇒ no
+ *   `@updatedAt` advance);
+ * - a generator's value is cached per id so a whole top-level mutation call
+ *   (e.g. a `createAll()` batch) shares one generated value across every row
+ *   it backs, matching `timestampNow`'s `'query'`-stability in SQL.
+ */
+import type { ExecutionMutationDefault, ExecutionMutationDefaultValue } from "@prisma-next/contract/types";
+
+/** Per-top-level-mutation-call cache, keyed by generator id. Create one with {@link createMutationDefaultsCache}. */
+export type MutationDefaultsCache = Map<string, unknown>;
+
+export function createMutationDefaultsCache(): MutationDefaultsCache {
+  return new Map();
+}
+
+function computeGeneratedValue(spec: ExecutionMutationDefaultValue): unknown {
+  switch (spec.id) {
+    case "timestampNow":
+      return new Date();
+    default:
+      throw new Error(`Unknown mutation-default generator id "${spec.id}"`);
+  }
+}
+
+function resolveGeneratedValue(spec: ExecutionMutationDefaultValue, cache: MutationDefaultsCache): unknown {
+  const cached = cache.get(spec.id);
+  if (cached !== undefined) return cached;
+  const value = computeGeneratedValue(spec);
+  cache.set(spec.id, value);
+  return value;
+}
+
+/**
+ * Fills in every column with an `onCreate` default that `data` doesn't
+ * already set. Returns `data` unchanged (same reference) if there's nothing
+ * to apply.
+ */
+export function applyCreateDefaults(
+  defaults: readonly ExecutionMutationDefault[] | undefined,
+  storeName: string,
+  data: Record<string, unknown>,
+  cache: MutationDefaultsCache
+): Record<string, unknown> {
+  if (!defaults || defaults.length === 0) return data;
+  let result = data;
+  for (const d of defaults) {
+    if (d.ref.table !== storeName || !d.onCreate) continue;
+    if (Object.hasOwn(result, d.ref.column)) continue;
+    if (result === data) result = { ...data };
+    result[d.ref.column] = resolveGeneratedValue(d.onCreate, cache);
+  }
+  return result;
+}
+
+/**
+ * Fills in every column with an `onUpdate` default that `patch` doesn't
+ * already set. An empty `patch` is returned unchanged — no write means no
+ * default should fire either (matches SQL's "empty update payloads skip
+ * onUpdate defaults" rule).
+ */
+export function applyUpdateDefaults(
+  defaults: readonly ExecutionMutationDefault[] | undefined,
+  storeName: string,
+  patch: Record<string, unknown>,
+  cache: MutationDefaultsCache
+): Record<string, unknown> {
+  if (Object.keys(patch).length === 0) return patch;
+  if (!defaults || defaults.length === 0) return patch;
+  let result = patch;
+  for (const d of defaults) {
+    if (d.ref.table !== storeName || !d.onUpdate) continue;
+    if (Object.hasOwn(result, d.ref.column)) continue;
+    if (result === patch) result = { ...patch };
+    result[d.ref.column] = resolveGeneratedValue(d.onUpdate, cache);
+  }
+  return result;
+}

--- a/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
@@ -1,18 +1,23 @@
 /**
  * Applies `contract.execution.mutations.defaults` (ADR 158) during a
  * create/update — IDB's equivalent of the SQL family's
- * `ExecutionContext.applyMutationDefaults`. Today the only generator id is
- * `"timestampNow"`, backing `temporal.updatedAt()` fields.
+ * `ExecutionContext.applyMutationDefaults`.
  *
  * Semantics mirror the SQL reference implementation:
  * - a caller-provided value always wins over a default;
  * - an empty update patch skips every `onUpdate` default (no write ⇒ no
  *   `@updatedAt` advance);
- * - a generator's value is cached per id so a whole top-level mutation call
- *   (e.g. a `createAll()` batch) shares one generated value across every row
- *   it backs, matching `timestampNow`'s `'query'`-stability in SQL.
+ * - `timestampNow`'s value is cached per call so a whole top-level mutation
+ *   call (e.g. a `createAll()` batch) shares one generated value across
+ *   every row it backs, matching its `'query'`-stability in SQL. Every other
+ *   generator (`literal`, `uuidv4`, `uuidv7`, `cuid2`) is deliberately *not*
+ *   cached — an id generator must produce a fresh, unique value per
+ *   resolution (both across rows in a batch and across distinct defaulted
+ *   fields on the same row), and a cache keyed only by generator id would
+ *   otherwise leak one field's/row's value onto the next.
  */
 import type { ExecutionMutationDefault, ExecutionMutationDefaultValue } from "@prisma-next/contract/types";
+import { generateId } from "@prisma-next/ids/runtime";
 import type { IdbMutationDefaultGeneratorId } from "@prisma-next-idb/target-idb/pack";
 
 /** Per-top-level-mutation-call cache, keyed by generator id. Create one with {@link createMutationDefaultsCache}. */
@@ -22,11 +27,20 @@ export function createMutationDefaultsCache(): MutationDefaultsCache {
   return new Map();
 }
 
+/** Generator ids whose value is shared across an entire top-level call. Every other id always regenerates. */
+const CACHEABLE_GENERATOR_IDS: ReadonlySet<IdbMutationDefaultGeneratorId> = new Set(["timestampNow"]);
+
 function computeGeneratedValue(spec: ExecutionMutationDefaultValue): unknown {
   const id = spec.id as IdbMutationDefaultGeneratorId;
   switch (id) {
     case "timestampNow":
       return new Date();
+    case "literal":
+      return spec.params?.["value"];
+    case "uuidv4":
+    case "uuidv7":
+    case "cuid2":
+      return generateId(spec.params !== undefined ? { id, params: spec.params } : { id });
     default: {
       const _exhaustive: never = id;
       throw new Error(`Unknown mutation-default generator id "${String(_exhaustive)}"`);
@@ -35,10 +49,12 @@ function computeGeneratedValue(spec: ExecutionMutationDefaultValue): unknown {
 }
 
 function resolveGeneratedValue(spec: ExecutionMutationDefaultValue, cache: MutationDefaultsCache): unknown {
-  const cached = cache.get(spec.id);
+  const id = spec.id as IdbMutationDefaultGeneratorId;
+  if (!CACHEABLE_GENERATOR_IDS.has(id)) return computeGeneratedValue(spec);
+  const cached = cache.get(id);
   if (cached !== undefined) return cached;
   const value = computeGeneratedValue(spec);
-  cache.set(spec.id, value);
+  cache.set(id, value);
   return value;
 }
 

--- a/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-defaults.ts
@@ -13,6 +13,7 @@
  *   it backs, matching `timestampNow`'s `'query'`-stability in SQL.
  */
 import type { ExecutionMutationDefault, ExecutionMutationDefaultValue } from "@prisma-next/contract/types";
+import type { IdbMutationDefaultGeneratorId } from "@prisma-next-idb/target-idb/pack";
 
 /** Per-top-level-mutation-call cache, keyed by generator id. Create one with {@link createMutationDefaultsCache}. */
 export type MutationDefaultsCache = Map<string, unknown>;
@@ -22,11 +23,14 @@ export function createMutationDefaultsCache(): MutationDefaultsCache {
 }
 
 function computeGeneratedValue(spec: ExecutionMutationDefaultValue): unknown {
-  switch (spec.id) {
+  const id = spec.id as IdbMutationDefaultGeneratorId;
+  switch (id) {
     case "timestampNow":
       return new Date();
-    default:
-      throw new Error(`Unknown mutation-default generator id "${spec.id}"`);
+    default: {
+      const _exhaustive: never = id;
+      throw new Error(`Unknown mutation-default generator id "${String(_exhaustive)}"`);
+    }
   }
 }
 

--- a/packages/prisma-next/client-idb/src/core/mutation-executor.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-executor.ts
@@ -5,7 +5,11 @@
  * from the SQL vendor:
  *
  * - No column/field mapping — IDB field names ARE the storage keys.
- * - No `applyMutationDefaults` — IDB has no server-side defaults.
+ * - `applyCreateDefaults`/`applyUpdateDefaults` (`mutation-defaults.ts`) fill
+ *   in `contract.execution.mutations.defaults` (currently just
+ *   `temporal.updatedAt()`'s `timestampNow` generator) — IDB has no
+ *   server-rendered defaults, so this always runs client-side, unlike SQL's
+ *   storage-plane `ColumnDefault`.
  * - `insertSingleRow` → `scope.execute({ kind: "add", ... })`.
  * - `findRowByCriterion` / `findFirstByFilters` → `scope.execute({ kind: "cursor-scan", ... })`.
  *   IDB allows reads inside a readwrite transaction; the transaction scope accepts
@@ -28,6 +32,12 @@ import { evaluateFilter, shorthandToFilterExpr } from "@prisma-next-idb/adapter-
 import type { IdbFilterExpr } from "@prisma-next-idb/adapter-idb/runtime";
 import type { IdbReferentialAction } from "@prisma-next-idb/target-idb/pack";
 import type { IdbQueryExecutor } from "./executor";
+import {
+  applyCreateDefaults,
+  applyUpdateDefaults,
+  createMutationDefaultsCache,
+  type MutationDefaultsCache,
+} from "./mutation-defaults";
 import { withMutationScope, type IdbQueryExecutorWithTransaction } from "./mutation-scope";
 import { createRelationMutator, isRelationMutationCallback, isRelationMutationDescriptor } from "./relation-mutator";
 import {
@@ -160,7 +170,10 @@ export async function executeNestedCreateMutation(options: {
   const { executor, contract, modelName, data } = options;
   const record = data as Record<string, unknown>;
   const storeNames = collectStoreNames(contract, modelName, record);
-  return withMutationScope(executor, storeNames, (scope) => createGraph(scope, contract, modelName, record));
+  const defaultsCache = createMutationDefaultsCache();
+  return withMutationScope(executor, storeNames, (scope) =>
+    createGraph(scope, contract, modelName, record, defaultsCache)
+  );
 }
 
 export async function executeNestedUpdateMutation(options: {
@@ -173,8 +186,9 @@ export async function executeNestedUpdateMutation(options: {
   const { executor, contract, modelName, filters, data } = options;
   const record = data as Record<string, unknown>;
   const storeNames = collectStoreNames(contract, modelName, record);
+  const defaultsCache = createMutationDefaultsCache();
   return withMutationScope(executor, storeNames, (scope) =>
-    updateFirstGraph(scope, contract, modelName, filters, record)
+    updateFirstGraph(scope, contract, modelName, filters, record, defaultsCache)
   );
 }
 
@@ -196,7 +210,8 @@ async function createGraph(
   scope: IdbTransactionScope,
   contract: IdbContract,
   modelName: string,
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  defaultsCache: MutationDefaultsCache
 ): Promise<Record<string, unknown>> {
   const parsed = parseMutationInput(contract, modelName, input);
   const { parentOwned, childOwned } = partitionByOwnership(parsed.relationMutations);
@@ -207,16 +222,16 @@ async function createGraph(
     if (item.mutation.kind === "disconnect") {
       throw new Error("disconnect() is only supported in update() nested mutations");
     }
-    await applyParentOwnedMutation(scope, contract, modelName, scalarData, item.relation, item.mutation);
+    await applyParentOwnedMutation(scope, contract, modelName, scalarData, item.relation, item.mutation, defaultsCache);
   }
 
-  const parentRow = await insertSingleRow(scope, contract, modelName, scalarData);
+  const parentRow = await insertSingleRow(scope, contract, modelName, scalarData, defaultsCache);
 
   for (const item of childOwned) {
     if (item.mutation.kind === "disconnect") {
       throw new Error("disconnect() is only supported in update() nested mutations");
     }
-    await applyChildOwnedMutation(scope, contract, modelName, parentRow, item.relation, item.mutation);
+    await applyChildOwnedMutation(scope, contract, modelName, parentRow, item.relation, item.mutation, defaultsCache);
   }
 
   return parentRow;
@@ -227,7 +242,8 @@ async function updateFirstGraph(
   contract: IdbContract,
   modelName: string,
   filters: readonly IdbFilterExpr[],
-  input: Record<string, unknown>
+  input: Record<string, unknown>,
+  defaultsCache: MutationDefaultsCache
 ): Promise<Record<string, unknown> | null> {
   const existingRow = await findFirstByFilters(scope, contract, modelName, filters);
   if (!existingRow) return null;
@@ -238,7 +254,7 @@ async function updateFirstGraph(
   const scalarData = { ...parsed.scalarData };
 
   for (const item of parentOwned) {
-    await applyParentOwnedMutation(scope, contract, modelName, scalarData, item.relation, item.mutation);
+    await applyParentOwnedMutation(scope, contract, modelName, scalarData, item.relation, item.mutation, defaultsCache);
   }
 
   let parentRow = existingRow;
@@ -248,13 +264,14 @@ async function updateFirstGraph(
     const keyPath = getKeyPath(contract, modelName);
     const key = existingRow[keyPath] as IDBValidKey;
     const meta = makePlanMeta(contract);
-    const rows = await scope.execute({ meta, kind: "update", storeName, key, patch: scalarData });
+    const patch = applyUpdateDefaults(contract.execution?.mutations.defaults, storeName, scalarData, defaultsCache);
+    const rows = await scope.execute({ meta, kind: "update", storeName, key, patch });
     const updated = rows[0];
     if (updated) parentRow = updated;
   }
 
   for (const item of childOwned) {
-    await applyChildOwnedMutation(scope, contract, modelName, parentRow, item.relation, item.mutation);
+    await applyChildOwnedMutation(scope, contract, modelName, parentRow, item.relation, item.mutation, defaultsCache);
   }
 
   return parentRow;
@@ -325,7 +342,8 @@ async function applyParentOwnedMutation(
   parentModelName: string,
   scalarData: Record<string, unknown>,
   relation: RelationDefinition,
-  mutation: IdbRelationMutation<IdbContract, string>
+  mutation: IdbRelationMutation<IdbContract, string>,
+  defaultsCache: MutationDefaultsCache
 ): Promise<void> {
   if (mutation.kind === "disconnect") {
     for (const localField of relation.localFields) {
@@ -341,7 +359,7 @@ async function applyParentOwnedMutation(
     }
     // Recursive nesting is not supported in Phase 6.4 — the nested record must
     // be a plain scalar create, not itself a nested mutation.
-    const relatedRow = await insertSingleRow(scope, contract, relation.relatedModelName, row);
+    const relatedRow = await insertSingleRow(scope, contract, relation.relatedModelName, row, defaultsCache);
     copyRelatedValuesToParent(relation, scalarData, relatedRow, parentModelName, contract);
     return;
   }
@@ -382,7 +400,8 @@ async function applyChildOwnedMutation(
   parentModelName: string,
   parentRow: Record<string, unknown>,
   relation: RelationDefinition,
-  mutation: IdbRelationMutation<IdbContract, string>
+  mutation: IdbRelationMutation<IdbContract, string>,
+  defaultsCache: MutationDefaultsCache
 ): Promise<void> {
   // parentValues: childFkField → parentPkValue (e.g. "authorId" → "u1")
   const parentValues = readParentColumnValues(parentModelName, relation, parentRow);
@@ -393,7 +412,7 @@ async function applyChildOwnedMutation(
       for (const [childField, parentValue] of parentValues.entries()) {
         payload[childField] = parentValue;
       }
-      await insertSingleRow(scope, contract, relation.relatedModelName, payload);
+      await insertSingleRow(scope, contract, relation.relatedModelName, payload, defaultsCache);
     }
     return;
   }
@@ -488,13 +507,15 @@ async function insertSingleRow(
   scope: IdbTransactionScope,
   contract: IdbContract,
   modelName: string,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  defaultsCache: MutationDefaultsCache
 ): Promise<Record<string, unknown>> {
   assertNoNestedCallbacks(modelName, data);
   const storeName = getStoreName(contract, modelName);
   const meta = makePlanMeta(contract);
-  const rows = await scope.execute({ meta, kind: "add", storeName, record: data });
-  return rows[0] ?? data;
+  const record = applyCreateDefaults(contract.execution?.mutations.defaults, storeName, data, defaultsCache);
+  const rows = await scope.execute({ meta, kind: "add", storeName, record });
+  return rows[0] ?? record;
 }
 
 /**
@@ -703,7 +724,7 @@ export async function executeScalarCreateWithFkValidation(options: {
   const storeNames = collectScalarFkStoreNames(contract, modelName, data);
   return withMutationScope(executor, storeNames, async (scope) => {
     await validateScalarFks(scope, contract, modelName, data);
-    return insertSingleRow(scope, contract, modelName, data);
+    return insertSingleRow(scope, contract, modelName, data, createMutationDefaultsCache());
   });
 }
 
@@ -724,12 +745,18 @@ export async function executeScalarUpdateWithFkValidation(options: {
       filters.length === 0 ? undefined : filters.length === 1 ? filters[0]! : { kind: "and" as const, exprs: filters };
     const filter =
       combined !== undefined ? (row: Record<string, unknown>): boolean => evaluateFilter(combined, row) : undefined;
+    const patch = applyUpdateDefaults(
+      contract.execution?.mutations.defaults,
+      storeName,
+      data,
+      createMutationDefaultsCache()
+    );
     const rows = await scope.execute({
       meta,
       kind: "scan-write",
       storeName,
       write: "put-merged",
-      patch: data,
+      patch,
       take: 1,
       ...(filter !== undefined ? { filter } : {}),
     } as IdbAtomicPlan);
@@ -770,12 +797,18 @@ export async function executeBulkUpdateWithFkValidation(options: {
       filters.length === 0 ? undefined : filters.length === 1 ? filters[0]! : { kind: "and" as const, exprs: filters };
     const filter =
       combined !== undefined ? (row: Record<string, unknown>): boolean => evaluateFilter(combined, row) : undefined;
+    const patch = applyUpdateDefaults(
+      contract.execution?.mutations.defaults,
+      storeName,
+      data,
+      createMutationDefaultsCache()
+    );
     return scope.execute({
       meta,
       kind: "scan-write",
       storeName,
       write: "put-merged",
-      patch: data,
+      patch,
       ...(filter !== undefined ? { filter } : {}),
     } as IdbAtomicPlan);
   });

--- a/packages/prisma-next/client-idb/src/core/mutation-executor.ts
+++ b/packages/prisma-next/client-idb/src/core/mutation-executor.ts
@@ -6,10 +6,10 @@
  *
  * - No column/field mapping — IDB field names ARE the storage keys.
  * - `applyCreateDefaults`/`applyUpdateDefaults` (`mutation-defaults.ts`) fill
- *   in `contract.execution.mutations.defaults` (currently just
- *   `temporal.updatedAt()`'s `timestampNow` generator) — IDB has no
- *   server-rendered defaults, so this always runs client-side, unlike SQL's
- *   storage-plane `ColumnDefault`.
+ *   in every generator id `contract.execution.mutations.defaults` declares
+ *   (see `IdbMutationDefaultGeneratorId`) — IDB has no server-rendered
+ *   defaults, so this always runs client-side, unlike SQL's storage-plane
+ *   `ColumnDefault`.
  * - `insertSingleRow` → `scope.execute({ kind: "add", ... })`.
  * - `findRowByCriterion` / `findFirstByFilters` → `scope.execute({ kind: "cursor-scan", ... })`.
  *   IDB allows reads inside a readwrite transaction; the transaction scope accepts
@@ -423,6 +423,12 @@ async function applyChildOwnedMutation(
       for (const [childField, parentValue] of parentValues.entries()) {
         setValues[childField] = parentValue;
       }
+      const patch = applyUpdateDefaults(
+        contract.execution?.mutations.defaults,
+        relation.relatedStoreName,
+        setValues,
+        defaultsCache
+      );
       const filter = buildCriterionFilter(criterion as Record<string, unknown>);
       const meta = makePlanMeta(contract);
       // scan-write + put-merged: set the FK fields on every child row matching
@@ -434,7 +440,7 @@ async function applyChildOwnedMutation(
         kind: "scan-write",
         storeName: relation.relatedStoreName,
         write: "put-merged",
-        patch: setValues,
+        patch,
         filter,
       });
     }
@@ -450,13 +456,19 @@ async function applyChildOwnedMutation(
 
   if (!mutation.criteria || mutation.criteria.length === 0) {
     // Disconnect all children of this parent.
+    const patch = applyUpdateDefaults(
+      contract.execution?.mutations.defaults,
+      relation.relatedStoreName,
+      setValues,
+      defaultsCache
+    );
     const parentJoinFilter = buildParentJoinFilter(parentValues);
     await scope.execute({
       meta,
       kind: "scan-write",
       storeName: relation.relatedStoreName,
       write: "put-merged",
-      patch: setValues,
+      patch,
       filter: parentJoinFilter,
     });
     return;
@@ -464,6 +476,12 @@ async function applyChildOwnedMutation(
 
   // Disconnect specific children matching each criterion AND the parent join.
   for (const criterion of mutation.criteria) {
+    const patch = applyUpdateDefaults(
+      contract.execution?.mutations.defaults,
+      relation.relatedStoreName,
+      setValues,
+      defaultsCache
+    );
     const criterionFilter = buildCriterionFilter(criterion as Record<string, unknown>);
     const parentJoinFilter = buildParentJoinFilter(parentValues);
     const combinedFilter = (row: Record<string, unknown>): boolean => parentJoinFilter(row) && criterionFilter(row);
@@ -472,7 +490,7 @@ async function applyChildOwnedMutation(
       kind: "scan-write",
       storeName: relation.relatedStoreName,
       write: "put-merged",
-      patch: setValues,
+      patch,
       filter: combinedFilter,
     });
   }

--- a/packages/prisma-next/client-idb/src/core/store-accessor.ts
+++ b/packages/prisma-next/client-idb/src/core/store-accessor.ts
@@ -61,6 +61,7 @@ import {
 } from "./aggregate-builder";
 import { type IdbGroupedAccessor, createGroupedAccessor } from "./grouped-accessor";
 import type { IdbQueryExecutor } from "./executor";
+import { applyCreateDefaults, applyUpdateDefaults, createMutationDefaultsCache } from "./mutation-defaults";
 import { loadRelation } from "./relation-loader";
 import {
   executeBulkUpdateWithFkValidation,
@@ -580,17 +581,23 @@ export class IdbStoreAccessorImpl<
 
     const groupingKey = this.#newGroupingKey();
     const meta = this.#planMeta(groupingKey);
-    const ast: IdbCreateAst = { kind: "create", modelName: this.#modelName, data: record };
+    const withDefaults = applyCreateDefaults(
+      this.#contract.execution?.mutations.defaults,
+      this.#storeName,
+      record,
+      createMutationDefaultsCache()
+    );
+    const ast: IdbCreateAst = { kind: "create", modelName: this.#modelName, data: withDefaults };
     const plan: IdbQueryPlan<Record<string, unknown>> = {
       meta,
       ast,
-      idbPlan: { meta, kind: "add", storeName: this.#storeName, record },
+      idbPlan: { meta, kind: "add", storeName: this.#storeName, record: withDefaults },
     };
     // The IDB driver echoes the stored record back as the single result row.
     for await (const row of this.#executor.execute(plan)) {
       return row as DefaultModelRow<TContract, ModelName>;
     }
-    return record as DefaultModelRow<TContract, ModelName>;
+    return withDefaults as DefaultModelRow<TContract, ModelName>;
   }
 
   async findUnique(key: KeyType<TContract, ModelName>): Promise<DefaultModelRow<TContract, ModelName> | null> {
@@ -728,16 +735,19 @@ export class IdbStoreAccessorImpl<
     // find-then-write in a single readwrite transaction so there is no
     // check-then-act race window. Mirrors the vendor's single-statement upsert.
     const exec = this.#executor as IdbQueryExecutor & Partial<Pick<IdbQueryExecutorWithTransaction, "transaction">>;
+    const executionDefaults = this.#contract.execution?.mutations.defaults;
     if (typeof exec.transaction === "function") {
       return withMutationScope(exec as IdbQueryExecutorWithTransaction, [storeName], async (scope) => {
         const found = await scope.execute({ meta, kind: "cursor-scan", storeName, filter: matches, take: 1 });
         const existing = found[0];
         if (existing === undefined) {
-          const rows = await scope.execute({ meta, kind: "add", storeName, record: createRecord });
-          return (rows[0] ?? createRecord) as DefaultModelRow<TContract, ModelName>;
+          const record = applyCreateDefaults(executionDefaults, storeName, createRecord, createMutationDefaultsCache());
+          const rows = await scope.execute({ meta, kind: "add", storeName, record });
+          return (rows[0] ?? record) as DefaultModelRow<TContract, ModelName>;
         }
         const key = existing[keyPath] as IDBValidKey;
-        const rows = await scope.execute({ meta, kind: "update", storeName, key, patch: patchRecord });
+        const patch = applyUpdateDefaults(executionDefaults, storeName, patchRecord, createMutationDefaultsCache());
+        const rows = await scope.execute({ meta, kind: "update", storeName, key, patch });
         return (rows[0] ?? existing) as DefaultModelRow<TContract, ModelName>;
       });
     }
@@ -752,17 +762,18 @@ export class IdbStoreAccessorImpl<
       return this.create(args.create as MutationCreateInput<TContract, ModelName>);
     }
     const key = (existing as Record<string, unknown>)[keyPath] as IDBValidKey;
+    const patch = applyUpdateDefaults(executionDefaults, storeName, patchRecord, createMutationDefaultsCache());
     const ast: IdbUpsertAst = {
       kind: "upsert",
       modelName: this.#modelName,
       create: createRecord,
-      update: patchRecord,
+      update: patch,
       where: args.where as Record<string, unknown>,
     };
     const plan: IdbQueryPlan<Record<string, unknown>> = {
       meta,
       ast,
-      idbPlan: { meta, kind: "update", storeName, key, patch: patchRecord },
+      idbPlan: { meta, kind: "update", storeName, key, patch },
     };
     for await (const row of this.#executor.execute(plan)) {
       return row as DefaultModelRow<TContract, ModelName>;
@@ -773,7 +784,14 @@ export class IdbStoreAccessorImpl<
   createAll(data: CreateInput<TContract, ModelName>[]): AsyncIterableResult<DefaultModelRow<TContract, ModelName>> {
     const groupingKey = this.#newGroupingKey();
     const meta = this.#planMeta(groupingKey);
-    const records = data.map((d) => d as Record<string, unknown>);
+    // One shared cache for the whole batch — every row in a single createAll()
+    // call gets the same generated `temporal.updatedAt()` timestamp, matching
+    // SQL's 'query'-stability semantics for the same generator.
+    const defaultsCache = createMutationDefaultsCache();
+    const executionDefaults = this.#contract.execution?.mutations.defaults;
+    const records = data.map((d) =>
+      applyCreateDefaults(executionDefaults, this.#storeName, d as Record<string, unknown>, defaultsCache)
+    );
     const ast: IdbCreateAllAst = { kind: "createAll", modelName: this.#modelName, data: records };
     const plan: IdbQueryPlan<Record<string, unknown>> = {
       meta,

--- a/packages/prisma-next/client-idb/src/core/types.ts
+++ b/packages/prisma-next/client-idb/src/core/types.ts
@@ -131,16 +131,56 @@ export type KeyType<TContract, ModelName extends string> =
 type KeyPathField<TContract, ModelName extends string> = ModelKeyPath<TContract, ModelName> &
   keyof ResolvedInputRow<TContract, ModelName>;
 
+/** The object store name for a model, extracted from `contract.domain...storage.storeName` (used to match `execution.mutations.defaults[].ref.table`). */
+type ModelStoreName<TContract, ModelName extends string> = ModelName extends keyof ModelsOf<TContract>
+  ? ModelsOf<TContract>[ModelName] extends { readonly storage: { readonly storeName: infer S } }
+    ? S extends string
+      ? S
+      : never
+    : never
+  : never;
+
+/** The flattened `execution.mutations.defaults` array type, or `never` for a contract with no execution section. */
+type ExecutionDefaultsOf<TContract> = TContract extends {
+  readonly execution: { readonly mutations: { readonly defaults: infer D } };
+}
+  ? D extends readonly unknown[]
+    ? D[number]
+    : never
+  : never;
+
+/**
+ * Column names with an `onCreate` execution default for this model's store —
+ * e.g. `temporal.updatedAt()`/bare `@updatedAt` fields, or any
+ * `@default(...)` field (literal, `now()`, `uuid()`, `cuid()`). These are
+ * omittable in `create()` even though the field itself isn't nullable,
+ * since the runtime fills them in (`client-idb/src/core/mutation-defaults.ts`).
+ */
+type FieldsWithCreateDefault<TContract, ModelName extends string> = Extract<
+  ExecutionDefaultsOf<TContract>,
+  { readonly ref: { readonly table: ModelStoreName<TContract, ModelName> }; readonly onCreate: unknown }
+>["ref"]["column"];
+
+/** {@link FieldsWithCreateDefault}, narrowed to keys that actually exist on the resolved input row (may be absent for models with no typed maps). */
+type DefaultedInputField<TContract, ModelName extends string> = FieldsWithCreateDefault<TContract, ModelName> &
+  keyof ResolvedInputRow<TContract, ModelName>;
+
 /**
  * Input shape for `create()`: the full input row with the primary key field
  * made optional (IDB can generate keys via `autoIncrement`, or clients may
- * omit the key when using `cuid()` / `uuid()` at the application layer).
+ * omit the key when using `cuid()` / `uuid()` at the application layer), and
+ * every other field with an `onCreate` execution default also made optional.
  */
 export type CreateInput<TContract, ModelName extends string> = Omit<
   ResolvedInputRow<TContract, ModelName>,
-  ModelKeyPath<TContract, ModelName>
+  ModelKeyPath<TContract, ModelName> | FieldsWithCreateDefault<TContract, ModelName>
 > &
-  Partial<Pick<ResolvedInputRow<TContract, ModelName>, KeyPathField<TContract, ModelName>>>;
+  Partial<
+    Pick<
+      ResolvedInputRow<TContract, ModelName>,
+      KeyPathField<TContract, ModelName> | DefaultedInputField<TContract, ModelName>
+    >
+  >;
 
 // ── Relations ─────────────────────────────────────────────────────────────────
 

--- a/packages/prisma-next/client-idb/test/create-input.test.ts
+++ b/packages/prisma-next/client-idb/test/create-input.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `CreateInput` type-level tests.
+ *
+ * Pure compile-time checks — the assertions live in the type positions
+ * below, not in `expect(...)` calls. A real violation surfaces as a `tsc`
+ * error (caught by `pnpm check`), not a runtime test failure, so each
+ * "it" body just exercises the type and exists for discoverability/grouping.
+ *
+ * `defineContract()` (the TS-DSL used by other tests in this package)
+ * returns a plain `Contract<IdbStorage>` with no `IdbContractWithTypeMaps`
+ * phantom key, so `CreateInput` would silently fall back to
+ * `Record<string, unknown>` for it and this test would pass vacuously
+ * regardless of the type-level logic under test. Building the phantom-typed
+ * contract by hand instead reproduces the exact shape a real PSL-derived
+ * `contract.d.ts` carries (see `family-idb/src/core/emission.ts`'s
+ * `getContractWrapper`/`getTypeMapsExpression`).
+ */
+import { describe, it } from "vitest";
+import type { IdbContractWithTypeMaps, IdbTypeMaps } from "@prisma-next-idb/target-idb/pack";
+import type { CreateInput } from "../src/core/types";
+
+// Deliberately *not* `Contract<IdbStorage>` — every type-level helper
+// `CreateInput` depends on (`ModelsOf`, `ModelKeyPath`, `ExecutionDefaultsOf`)
+// pattern-matches structurally, so intersecting with the framework's generic
+// `ApplicationDomain`/`Contract` interfaces here would just fight this
+// fixture's literal shapes (its `domain.namespaces` is a wide index
+// signature, which collapses the literal `Post` entry back into a union on
+// `keyof` access). A minimal structural fixture is both sufficient and less
+// fragile.
+type BaseContract = {
+  readonly domain: {
+    readonly namespaces: {
+      readonly __unbound__: {
+        readonly models: {
+          readonly Post: {
+            readonly fields: Record<string, never>;
+            readonly relations: Record<string, never>;
+            readonly storage: { readonly storeName: "posts"; readonly keyPath: "id" };
+          };
+        };
+      };
+    };
+  };
+  readonly execution: {
+    readonly executionHash: string;
+    readonly mutations: {
+      readonly defaults: readonly [
+        {
+          readonly ref: { readonly namespace: "__unbound__"; readonly table: "posts"; readonly column: "title" };
+          readonly onCreate: { readonly kind: "generator"; readonly id: "timestampNow" };
+        },
+      ];
+    };
+  };
+};
+
+type PostRow = { readonly id: string; readonly authorId: string; readonly title: string };
+
+type TestTypeMaps = IdbTypeMaps<
+  Record<string, never>,
+  { readonly __unbound__: { readonly Post: PostRow } },
+  { readonly __unbound__: { readonly Post: PostRow } }
+>;
+
+type TestContract = IdbContractWithTypeMaps<BaseContract, TestTypeMaps>;
+
+type PostCreateInput = CreateInput<TestContract, "Post">;
+
+describe("CreateInput", () => {
+  it("makes a field with an onCreate execution default optional, alongside the key", () => {
+    const input: PostCreateInput = { authorId: "u1" };
+    void input;
+  });
+
+  it("still requires a field with no execution default", () => {
+    // @ts-expect-error — authorId has no default and must remain required.
+    const input: PostCreateInput = { title: "hello" };
+    void input;
+  });
+});

--- a/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
+++ b/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
@@ -1,0 +1,91 @@
+/**
+ * mutation-defaults unit tests.
+ *
+ * Exercises `applyCreateDefaults`/`applyUpdateDefaults` in isolation against
+ * hand-built `ExecutionMutationDefault[]` lists — the PSL → contract wiring
+ * that produces these lists (`temporal.updatedAt()`) is covered separately
+ * in family-idb's contract-psl.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import type { ExecutionMutationDefault } from "@prisma-next/contract/types";
+import { applyCreateDefaults, applyUpdateDefaults, createMutationDefaultsCache } from "../src/core/mutation-defaults";
+
+const updatedAtDefault: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "updatedAt" },
+  onCreate: { kind: "generator", id: "timestampNow" },
+  onUpdate: { kind: "generator", id: "timestampNow" },
+};
+
+describe("applyCreateDefaults", () => {
+  it("fills in a missing column from onCreate", () => {
+    const result = applyCreateDefaults([updatedAtDefault], "post", { id: "p1" }, createMutationDefaultsCache());
+    expect(result["updatedAt"]).toBeInstanceOf(Date);
+    expect(result["id"]).toBe("p1");
+  });
+
+  it("does not overwrite a caller-provided value", () => {
+    const explicit = new Date("2020-01-01T00:00:00.000Z");
+    const result = applyCreateDefaults(
+      [updatedAtDefault],
+      "post",
+      { id: "p1", updatedAt: explicit },
+      createMutationDefaultsCache()
+    );
+    expect(result["updatedAt"]).toBe(explicit);
+  });
+
+  it("ignores defaults for other stores", () => {
+    const result = applyCreateDefaults([updatedAtDefault], "user", { id: "u1" }, createMutationDefaultsCache());
+    expect(result).not.toHaveProperty("updatedAt");
+  });
+
+  it("returns the same object reference when there is nothing to apply", () => {
+    const data = { id: "p1" };
+    const result = applyCreateDefaults(undefined, "post", data, createMutationDefaultsCache());
+    expect(result).toBe(data);
+  });
+
+  it("shares one generated timestamp across a batch via a shared cache", () => {
+    const cache = createMutationDefaultsCache();
+    const a = applyCreateDefaults([updatedAtDefault], "post", { id: "p1" }, cache);
+    const b = applyCreateDefaults([updatedAtDefault], "post", { id: "p2" }, cache);
+    expect(a["updatedAt"]).toBe(b["updatedAt"]);
+  });
+
+  it("generates a fresh timestamp per call when given separate caches", async () => {
+    const a = applyCreateDefaults([updatedAtDefault], "post", { id: "p1" }, createMutationDefaultsCache());
+    await new Promise((r) => setTimeout(r, 2));
+    const b = applyCreateDefaults([updatedAtDefault], "post", { id: "p2" }, createMutationDefaultsCache());
+    expect((a["updatedAt"] as Date).getTime()).toBeLessThan((b["updatedAt"] as Date).getTime());
+  });
+});
+
+describe("applyUpdateDefaults", () => {
+  it("fills in onUpdate for a non-empty patch", () => {
+    const result = applyUpdateDefaults([updatedAtDefault], "post", { title: "new" }, createMutationDefaultsCache());
+    expect(result["updatedAt"]).toBeInstanceOf(Date);
+  });
+
+  it("does not overwrite a caller-provided value", () => {
+    const explicit = new Date("2020-01-01T00:00:00.000Z");
+    const result = applyUpdateDefaults(
+      [updatedAtDefault],
+      "post",
+      { updatedAt: explicit },
+      createMutationDefaultsCache()
+    );
+    expect(result["updatedAt"]).toBe(explicit);
+  });
+
+  it("skips every onUpdate default for an empty patch", () => {
+    const patch = {};
+    const result = applyUpdateDefaults([updatedAtDefault], "post", patch, createMutationDefaultsCache());
+    expect(result).toBe(patch);
+    expect(result).not.toHaveProperty("updatedAt");
+  });
+
+  it("ignores defaults for other stores", () => {
+    const result = applyUpdateDefaults([updatedAtDefault], "user", { name: "x" }, createMutationDefaultsCache());
+    expect(result).not.toHaveProperty("updatedAt");
+  });
+});

--- a/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
+++ b/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
@@ -60,6 +60,82 @@ describe("applyCreateDefaults", () => {
   });
 });
 
+const publishedDefault: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "published" },
+  onCreate: { kind: "generator", id: "literal", params: { value: false } },
+};
+
+const featuredDefault: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "featured" },
+  onCreate: { kind: "generator", id: "literal", params: { value: true } },
+};
+
+const idUuidV4Default: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "id" },
+  onCreate: { kind: "generator", id: "uuidv4" },
+};
+
+const idUuidV7Default: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "id" },
+  onCreate: { kind: "generator", id: "uuidv7" },
+};
+
+const idCuid2Default: ExecutionMutationDefault = {
+  ref: { namespace: "__unbound__", table: "post", column: "id" },
+  onCreate: { kind: "generator", id: "cuid2" },
+};
+
+const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CUID2_PATTERN = /^[a-z][a-z0-9]{23}$/;
+
+describe("applyCreateDefaults — literal generator", () => {
+  it("fills in the field's own literal value", () => {
+    const result = applyCreateDefaults([publishedDefault], "post", { id: "p1" }, createMutationDefaultsCache());
+    expect(result["published"]).toBe(false);
+  });
+
+  it("does not leak one field's literal value into another field's default", () => {
+    const result = applyCreateDefaults(
+      [publishedDefault, featuredDefault],
+      "post",
+      { id: "p1" },
+      createMutationDefaultsCache()
+    );
+    expect(result["published"]).toBe(false);
+    expect(result["featured"]).toBe(true);
+  });
+});
+
+describe("applyCreateDefaults — id generators (uuidv4/uuidv7/cuid2)", () => {
+  it("generates a valid uuidv4", () => {
+    const result = applyCreateDefaults([idUuidV4Default], "post", {}, createMutationDefaultsCache());
+    expect(result["id"]).toMatch(UUID_V4_PATTERN);
+  });
+
+  it("generates a valid uuidv7", () => {
+    const result = applyCreateDefaults([idUuidV7Default], "post", {}, createMutationDefaultsCache());
+    expect(result["id"]).toMatch(UUID_V7_PATTERN);
+  });
+
+  it("generates a valid cuid2", () => {
+    const result = applyCreateDefaults([idCuid2Default], "post", {}, createMutationDefaultsCache());
+    expect(result["id"]).toMatch(CUID2_PATTERN);
+  });
+
+  it("does not overwrite a caller-provided id", () => {
+    const result = applyCreateDefaults([idUuidV4Default], "post", { id: "explicit" }, createMutationDefaultsCache());
+    expect(result["id"]).toBe("explicit");
+  });
+
+  it("generates a unique id per row within the same batch cache, unlike timestampNow", () => {
+    const cache = createMutationDefaultsCache();
+    const a = applyCreateDefaults([idUuidV4Default], "post", {}, cache);
+    const b = applyCreateDefaults([idUuidV4Default], "post", {}, cache);
+    expect(a["id"]).not.toBe(b["id"]);
+  });
+});
+
 describe("applyUpdateDefaults", () => {
   it("fills in onUpdate for a non-empty patch", () => {
     const result = applyUpdateDefaults([updatedAtDefault], "post", { title: "new" }, createMutationDefaultsCache());

--- a/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
+++ b/packages/prisma-next/client-idb/test/mutation-defaults.test.ts
@@ -52,11 +52,20 @@ describe("applyCreateDefaults", () => {
     expect(a["updatedAt"]).toBe(b["updatedAt"]);
   });
 
-  it("generates a fresh timestamp per call when given separate caches", async () => {
+  it("generates an independent timestamp instance per call when given separate caches", () => {
     const a = applyCreateDefaults([updatedAtDefault], "post", { id: "p1" }, createMutationDefaultsCache());
-    await new Promise((r) => setTimeout(r, 2));
     const b = applyCreateDefaults([updatedAtDefault], "post", { id: "p2" }, createMutationDefaultsCache());
-    expect((a["updatedAt"] as Date).getTime()).toBeLessThan((b["updatedAt"] as Date).getTime());
+    expect(a["updatedAt"]).not.toBe(b["updatedAt"]);
+  });
+
+  it("treats an explicit undefined value the same as an absent column", () => {
+    const result = applyCreateDefaults(
+      [updatedAtDefault],
+      "post",
+      { id: "p1", updatedAt: undefined },
+      createMutationDefaultsCache()
+    );
+    expect(result["updatedAt"]).toBeInstanceOf(Date);
   });
 });
 
@@ -87,7 +96,9 @@ const idCuid2Default: ExecutionMutationDefault = {
 
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const CUID2_PATTERN = /^[a-z][a-z0-9]{23}$/;
+// uniku's cuid2 length bounds are 2-32 chars (default 24) — match the shape,
+// not a specific length, so this doesn't couple to the default.
+const CUID2_PATTERN = /^[a-z][a-z0-9]{1,31}$/;
 
 describe("applyCreateDefaults — literal generator", () => {
   it("fills in the field's own literal value", () => {
@@ -155,6 +166,13 @@ describe("applyUpdateDefaults", () => {
 
   it("skips every onUpdate default for an empty patch", () => {
     const patch = {};
+    const result = applyUpdateDefaults([updatedAtDefault], "post", patch, createMutationDefaultsCache());
+    expect(result).toBe(patch);
+    expect(result).not.toHaveProperty("updatedAt");
+  });
+
+  it("treats a patch whose fields are all undefined the same as an empty patch", () => {
+    const patch = { title: undefined };
     const result = applyUpdateDefaults([updatedAtDefault], "post", patch, createMutationDefaultsCache());
     expect(result).toBe(patch);
     expect(result).not.toHaveProperty("updatedAt");

--- a/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
+++ b/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
@@ -50,6 +50,30 @@ function parseDefaultLiteralValue(raw: string): { readonly value: string | numbe
   return undefined;
 }
 
+/**
+ * `true` if a parsed `@default(<literal>)` value's JS type matches what
+ * `codecId` expects (a literal's JS type must match the field's declared
+ * type — a string literal on an Int field, or vice versa, is a mismatch).
+ * Declared as a function (not a `codecId → JS type` const lookup) since
+ * `SCALAR_TO_CODEC_ID` — which every `codecId` here is sourced from — is
+ * declared further down this module; a top-level const initializer would hit
+ * the temporal dead zone, but a function body only evaluates when called.
+ */
+function literalValueMatchesCodec(value: string | number | boolean, codecId: string): boolean {
+  switch (codecId) {
+    case SCALAR_TO_CODEC_ID["String"]:
+      return typeof value === "string";
+    case SCALAR_TO_CODEC_ID["Int"]:
+    case SCALAR_TO_CODEC_ID["Float"]:
+    case SCALAR_TO_CODEC_ID["Decimal"]:
+      return typeof value === "number";
+    case SCALAR_TO_CODEC_ID["Boolean"]:
+      return typeof value === "boolean";
+    default:
+      return false;
+  }
+}
+
 /** Parses `@default(...)`'s positional argument as a function call: `name(...)` or bare `name()`. */
 function parseDefaultFunctionCall(raw: string): { readonly name: string; readonly arg?: string } | undefined {
   const trimmed = raw.trim();
@@ -673,6 +697,15 @@ function interpretModel(
 
       const literal = parseDefaultLiteralValue(raw);
       if (literal) {
+        if (!literalValueMatchesCodec(literal.value, codecId)) {
+          diagnostics.push({
+            code: "IDB_INVALID_DEFAULT_VALUE",
+            message: `Field "${model.name}.${field.name}" has type "${field.typeName}" but @default(${raw}) is a ${typeof literal.value} literal.`,
+            sourceId,
+            span: defaultAttr.span,
+          });
+          continue;
+        }
         fieldExecutionDefaults.push({
           fieldName: field.name,
           onCreate: { kind: "generator", id: LITERAL_GENERATOR_ID, params: { value: literal.value } },

--- a/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
+++ b/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
@@ -1,11 +1,12 @@
 import type { ContractSourceDiagnostic, ContractSourceDiagnostics } from "@prisma-next/config/config-types";
-import { computeProfileHash, computeStorageHash } from "@prisma-next/contract/hashing";
-import type { ApplicationDomain, Contract, ContractField } from "@prisma-next/contract/types";
+import { computeExecutionHash, computeProfileHash, computeStorageHash } from "@prisma-next/contract/hashing";
+import type { ApplicationDomain, Contract, ContractField, ExecutionMutationDefault } from "@prisma-next/contract/types";
 import { UNBOUND_DOMAIN_NAMESPACE_ID, crossRef } from "@prisma-next/contract/types";
 import type { FieldSymbol, ModelSymbol, SymbolTable } from "@prisma-next/psl-parser";
 import type {
   IdbIndexDefinition,
   IdbModelStorage,
+  IdbMutationDefaultGeneratorId,
   IdbReferentialAction,
   IdbStorage,
   IdbStoreDefinition,
@@ -13,6 +14,12 @@ import type {
 import { notOk, ok } from "@prisma-next/utils/result";
 import type { Result } from "@prisma-next/utils/result";
 import { validateContract } from "./validate";
+
+/** The one `temporal.*` type-constructor path IDB currently understands. */
+const TEMPORAL_UPDATED_AT_PATH = ["temporal", "updatedAt"] as const;
+
+/** Generator id shared by every `temporal.updatedAt()` field — fires on both onCreate and onUpdate. */
+const TIMESTAMP_NOW_GENERATOR_ID: IdbMutationDefaultGeneratorId = "timestampNow";
 
 // ── Scalar type → codec ID mapping ────────────────────────────────────────────
 
@@ -165,6 +172,8 @@ interface InterpretedModel {
   readonly relationsStorage: Record<string, { onDelete?: IdbReferentialAction }>;
   /** FK-side declarations keyed by targetModelName for back-relation resolution. */
   readonly fksByTarget: ReadonlyMap<string, { fieldName: string; localFields: string[]; targetFields: string[] }>;
+  /** Names of fields declared `temporal.updatedAt()` — feeds `contract.execution.mutations.defaults`. */
+  readonly temporalUpdatedAtFields: readonly string[];
 }
 
 // ── Core interpreter ───────────────────────────────────────────────────────────
@@ -308,6 +317,7 @@ function interpretModel(
   const relations: InterpretedModel["relations"] = {};
   const relationsStorage: Record<string, { onDelete?: IdbReferentialAction }> = {};
   const fksByTarget = new Map<string, { fieldName: string; localFields: string[]; targetFields: string[] }>();
+  const temporalUpdatedAtFields: string[] = [];
 
   for (const field of modelFields) {
     // Skip the @id field's optional marker — keyPath fields cannot be nullable in IDB
@@ -467,6 +477,53 @@ function interpretModel(
       continue;
     }
 
+    // `temporal.updatedAt()` — a namespaced type-constructor call in the type
+    // position (no plain type name), shared framework-level PSL grammar
+    // (same construct the SQL family requires in place of the removed bare
+    // `@updatedAt` attribute). Must be checked before the plain-scalar
+    // lookup below: `field.typeName` for a type-constructor field is just
+    // the call's last path segment ("updatedAt"), not a real scalar type.
+    if (field.typeConstructor) {
+      const path = field.typeConstructor.path;
+      const isTemporalUpdatedAt =
+        path.length === TEMPORAL_UPDATED_AT_PATH.length && path.every((p, i) => p === TEMPORAL_UPDATED_AT_PATH[i]);
+
+      if (!isTemporalUpdatedAt) {
+        diagnostics.push({
+          code: "IDB_UNSUPPORTED_TYPE_CONSTRUCTOR",
+          message: `Field "${model.name}.${field.name}" uses unsupported type constructor "${path.join(".")}()". IDB currently only supports temporal.updatedAt().`,
+          sourceId,
+          span: field.typeConstructor.span,
+        });
+        continue;
+      }
+      if (field.typeConstructor.args.length > 0) {
+        diagnostics.push({
+          code: "IDB_TEMPORAL_UPDATED_AT_TAKES_NO_ARGS",
+          message: `Field "${model.name}.${field.name}" — temporal.updatedAt() takes no arguments.`,
+          sourceId,
+          span: field.typeConstructor.span,
+        });
+        continue;
+      }
+      if (field.name === idFieldName) {
+        diagnostics.push({
+          code: "IDB_TEMPORAL_UPDATED_AT_ON_KEY_FIELD",
+          message: `Field "${model.name}.${field.name}" is the model's @id key and cannot be temporal.updatedAt() — an auto-managed timestamp cannot also be the primary key.`,
+          sourceId,
+          span: field.span,
+        });
+        continue;
+      }
+
+      contractFields[field.name] = {
+        nullable: field.optional,
+        type: { kind: "scalar", codecId: SCALAR_TO_CODEC_ID["DateTime"]! },
+      };
+      temporalUpdatedAtFields.push(field.name);
+      continue;
+    }
+
     const codecId = SCALAR_TO_CODEC_ID[field.typeName];
     if (codecId === undefined) {
       diagnostics.push({
@@ -534,6 +591,7 @@ function interpretModel(
     relations,
     relationsStorage,
     fksByTarget,
+    temporalUpdatedAtFields,
   };
 }
 
@@ -690,6 +748,7 @@ export function interpretPslDocumentToIdbContract(
   const stores: Record<string, IdbStoreDefinition> = {};
   const roots: Record<string, ReturnType<typeof crossRef>> = {};
   const domainModels: Record<string, unknown> = {};
+  const executionDefaults: ExecutionMutationDefault[] = [];
 
   for (const [modelName, interp] of interpretedByName) {
     stores[interp.storeName] = {
@@ -698,6 +757,14 @@ export function interpretPslDocumentToIdbContract(
     };
 
     roots[interp.storeName] = crossRef(modelName);
+
+    for (const fieldName of interp.temporalUpdatedAtFields) {
+      executionDefaults.push({
+        ref: { namespace: ns, table: interp.storeName, column: fieldName },
+        onCreate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+        onUpdate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+      });
+    }
 
     const modelStorage: IdbModelStorage =
       Object.keys(interp.relationsStorage).length > 0
@@ -738,6 +805,18 @@ export function interpretPslDocumentToIdbContract(
     namespaces: { [ns]: { models: domainModels } },
   } as unknown as ApplicationDomain;
 
+  const execution =
+    executionDefaults.length > 0
+      ? {
+          executionHash: computeExecutionHash({
+            target: "idb",
+            targetFamily: "idb",
+            execution: { mutations: { defaults: executionDefaults } },
+          }),
+          mutations: { defaults: executionDefaults },
+        }
+      : undefined;
+
   const contract: Contract<IdbStorage> = {
     target: "idb",
     targetFamily: "idb",
@@ -748,6 +827,7 @@ export function interpretPslDocumentToIdbContract(
     extensionPacks: {},
     meta: {},
     profileHash,
+    ...(execution ? { execution } : {}),
   };
 
   validateContract(contract);

--- a/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
+++ b/packages/prisma-next/family-idb/src/core/psl-interpreter.ts
@@ -18,8 +18,71 @@ import { validateContract } from "./validate";
 /** The one `temporal.*` type-constructor path IDB currently understands. */
 const TEMPORAL_UPDATED_AT_PATH = ["temporal", "updatedAt"] as const;
 
-/** Generator id shared by every `temporal.updatedAt()` field — fires on both onCreate and onUpdate. */
+/** Generator id shared by `temporal.updatedAt()`/bare `@updatedAt`/`@default(now())`. */
 const TIMESTAMP_NOW_GENERATOR_ID: IdbMutationDefaultGeneratorId = "timestampNow";
+
+/** Synthetic generator id that just echoes `params.value` — backs `@default(<literal>)`. */
+const LITERAL_GENERATOR_ID: IdbMutationDefaultGeneratorId = "literal";
+
+/** An execution-plane mutation default resolved for one field, pre-`ref` (the store name isn't known yet at field-resolution time). */
+interface FieldExecutionDefault {
+  readonly fieldName: string;
+  readonly onCreate?: {
+    readonly kind: "generator";
+    readonly id: IdbMutationDefaultGeneratorId;
+    readonly params?: Record<string, unknown>;
+  };
+  readonly onUpdate?: {
+    readonly kind: "generator";
+    readonly id: IdbMutationDefaultGeneratorId;
+    readonly params?: Record<string, unknown>;
+  };
+}
+
+/** Parses `@default(...)`'s positional argument as a literal value: `true`/`false`/a number/a quoted string. */
+function parseDefaultLiteralValue(raw: string): { readonly value: string | number | boolean } | undefined {
+  const t = raw.trim();
+  if (t === "true") return { value: true };
+  if (t === "false") return { value: false };
+  if (/^-?\d+(\.\d+)?$/.test(t)) return { value: Number(t) };
+  const str = parseStringArg(t);
+  if (str !== undefined) return { value: str };
+  return undefined;
+}
+
+/** Parses `@default(...)`'s positional argument as a function call: `name(...)` or bare `name()`. */
+function parseDefaultFunctionCall(raw: string): { readonly name: string; readonly arg?: string } | undefined {
+  const trimmed = raw.trim();
+  const openParen = trimmed.indexOf("(");
+  const closeParen = trimmed.lastIndexOf(")");
+  if (openParen <= 0 || closeParen !== trimmed.length - 1) return undefined;
+  const name = trimmed.slice(0, openParen).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return undefined;
+  const arg = trimmed.slice(openParen + 1, closeParen).trim();
+  return arg ? { name, arg } : { name };
+}
+
+type DefaultFunctionResolution =
+  | { readonly ok: true; readonly generatorId: IdbMutationDefaultGeneratorId }
+  | { readonly ok: false; readonly reason: "unknown-function" | "invalid-argument" };
+
+/** Resolves a parsed `@default(...)` function call (excluding `autoincrement()`, handled separately as a storage-plane concern) to a generator id. */
+function resolveDefaultFunctionGeneratorId(name: string, arg: string | undefined): DefaultFunctionResolution {
+  switch (name) {
+    case "now":
+      return arg === undefined
+        ? { ok: true, generatorId: TIMESTAMP_NOW_GENERATOR_ID }
+        : { ok: false, reason: "invalid-argument" };
+    case "uuid":
+      if (arg === undefined || arg === "4") return { ok: true, generatorId: "uuidv4" };
+      if (arg === "7") return { ok: true, generatorId: "uuidv7" };
+      return { ok: false, reason: "invalid-argument" };
+    case "cuid":
+      return arg === undefined ? { ok: true, generatorId: "cuid2" } : { ok: false, reason: "invalid-argument" };
+    default:
+      return { ok: false, reason: "unknown-function" };
+  }
+}
 
 // ── Scalar type → codec ID mapping ────────────────────────────────────────────
 
@@ -172,8 +235,10 @@ interface InterpretedModel {
   readonly relationsStorage: Record<string, { onDelete?: IdbReferentialAction }>;
   /** FK-side declarations keyed by targetModelName for back-relation resolution. */
   readonly fksByTarget: ReadonlyMap<string, { fieldName: string; localFields: string[]; targetFields: string[] }>;
-  /** Names of fields declared `temporal.updatedAt()` — feeds `contract.execution.mutations.defaults`. */
-  readonly temporalUpdatedAtFields: readonly string[];
+  /** Execution-plane defaults resolved from `temporal.updatedAt()`, bare `@updatedAt`, and `@default(...)` — feeds `contract.execution.mutations.defaults`. */
+  readonly fieldExecutionDefaults: readonly FieldExecutionDefault[];
+  /** `true` when `@default(autoincrement())` was declared on this model's `@id` field — feeds `IdbStoreDefinition.autoIncrement`. */
+  readonly autoIncrement: boolean;
 }
 
 // ── Core interpreter ───────────────────────────────────────────────────────────
@@ -317,7 +382,8 @@ function interpretModel(
   const relations: InterpretedModel["relations"] = {};
   const relationsStorage: Record<string, { onDelete?: IdbReferentialAction }> = {};
   const fksByTarget = new Map<string, { fieldName: string; localFields: string[]; targetFields: string[] }>();
-  const temporalUpdatedAtFields: string[] = [];
+  const fieldExecutionDefaults: FieldExecutionDefault[] = [];
+  let autoIncrement = false;
 
   for (const field of modelFields) {
     // Skip the @id field's optional marker — keyPath fields cannot be nullable in IDB
@@ -520,7 +586,11 @@ function interpretModel(
         nullable: field.optional,
         type: { kind: "scalar", codecId: SCALAR_TO_CODEC_ID["DateTime"]! },
       };
-      temporalUpdatedAtFields.push(field.name);
+      fieldExecutionDefaults.push({
+        fieldName: field.name,
+        onCreate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+        onUpdate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+      });
       continue;
     }
 
@@ -539,6 +609,142 @@ function interpretModel(
       nullable: field.optional,
       type: { kind: "scalar", codecId },
     };
+
+    // `@updatedAt` (classic Prisma spelling) — same runtime semantics as
+    // `temporal.updatedAt()` above, just a different PSL surface for the
+    // same "fires on both create and update" mutation default.
+    const updatedAtAttr = getFieldAttribute(field, "updatedAt");
+    const defaultAttr = getFieldAttribute(field, "default");
+
+    if (updatedAtAttr && defaultAttr) {
+      diagnostics.push({
+        code: "IDB_UPDATED_AT_AND_DEFAULT_CONFLICT",
+        message: `Field "${model.name}.${field.name}" cannot combine @updatedAt with @default(...).`,
+        sourceId,
+        span: defaultAttr.span,
+      });
+      continue;
+    }
+
+    if (updatedAtAttr) {
+      if (field.name === idFieldName) {
+        diagnostics.push({
+          code: "IDB_TEMPORAL_UPDATED_AT_ON_KEY_FIELD",
+          message: `Field "${model.name}.${field.name}" is the model's @id key and cannot be @updatedAt — an auto-managed timestamp cannot also be the primary key.`,
+          sourceId,
+          span: field.span,
+        });
+        continue;
+      }
+      if (field.optional) {
+        diagnostics.push({
+          code: "IDB_EXECUTION_DEFAULT_ON_OPTIONAL_FIELD",
+          message: `Field "${model.name}.${field.name}" cannot be both optional and @updatedAt — an omitted value would be ambiguous between "generate one" and "store null". Remove "?" or the attribute.`,
+          sourceId,
+          span: field.span,
+        });
+        continue;
+      }
+      if (codecId !== SCALAR_TO_CODEC_ID["DateTime"]) {
+        diagnostics.push({
+          code: "IDB_UPDATED_AT_NOT_DATETIME",
+          message: `Field "${model.name}.${field.name}" is marked @updatedAt but has type "${field.typeName}", not DateTime.`,
+          sourceId,
+          span: field.span,
+        });
+        continue;
+      }
+      fieldExecutionDefaults.push({
+        fieldName: field.name,
+        onCreate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+        onUpdate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+      });
+    } else if (defaultAttr) {
+      const raw = findPositionalArg(defaultAttr.args);
+      if (raw === undefined) {
+        diagnostics.push({
+          code: "IDB_INVALID_DEFAULT_VALUE",
+          message: `Field "${model.name}.${field.name}" @default(...) requires a positional argument.`,
+          sourceId,
+          span: defaultAttr.span,
+        });
+        continue;
+      }
+
+      const literal = parseDefaultLiteralValue(raw);
+      if (literal) {
+        fieldExecutionDefaults.push({
+          fieldName: field.name,
+          onCreate: { kind: "generator", id: LITERAL_GENERATOR_ID, params: { value: literal.value } },
+        });
+      } else {
+        const call = parseDefaultFunctionCall(raw);
+        if (!call) {
+          diagnostics.push({
+            code: "IDB_INVALID_DEFAULT_VALUE",
+            message: `Field "${model.name}.${field.name}" has unsupported default value "${raw}".`,
+            sourceId,
+            span: defaultAttr.span,
+          });
+          continue;
+        }
+
+        if (call.name === "autoincrement") {
+          if (field.name !== idFieldName) {
+            diagnostics.push({
+              code: "IDB_AUTOINCREMENT_NOT_ON_KEY_FIELD",
+              message: `Field "${model.name}.${field.name}" uses @default(autoincrement()) but is not the model's @id key. IndexedDB only generates keys for the primary key field.`,
+              sourceId,
+              span: defaultAttr.span,
+            });
+            continue;
+          }
+          if (codecId !== SCALAR_TO_CODEC_ID["Int"]) {
+            diagnostics.push({
+              code: "IDB_AUTOINCREMENT_NOT_INT",
+              message: `Field "${model.name}.${field.name}" uses @default(autoincrement()) but has type "${field.typeName}", not Int. IndexedDB key generators only produce numbers.`,
+              sourceId,
+              span: defaultAttr.span,
+            });
+            continue;
+          }
+          autoIncrement = true;
+          continue;
+        }
+
+        if (field.optional) {
+          diagnostics.push({
+            code: "IDB_EXECUTION_DEFAULT_ON_OPTIONAL_FIELD",
+            message: `Field "${model.name}.${field.name}" cannot be both optional and @default(${call.name}(...)) — an omitted value would be ambiguous between "generate one" and "store null". Remove "?" or the default.`,
+            sourceId,
+            span: defaultAttr.span,
+          });
+          continue;
+        }
+
+        const resolution = resolveDefaultFunctionGeneratorId(call.name, call.arg);
+        if (!resolution.ok) {
+          diagnostics.push({
+            code:
+              resolution.reason === "unknown-function"
+                ? "IDB_UNKNOWN_DEFAULT_FUNCTION"
+                : "IDB_INVALID_DEFAULT_FUNCTION_ARGUMENT",
+            message:
+              resolution.reason === "unknown-function"
+                ? `Field "${model.name}.${field.name}" uses unsupported default function "${call.name}(...)". Supported: now(), uuid(), uuid(7), cuid(), autoincrement().`
+                : `Field "${model.name}.${field.name}" — @default(${call.name}(${call.arg ?? ""})) has an unsupported argument.`,
+            sourceId,
+            span: defaultAttr.span,
+          });
+          continue;
+        }
+
+        fieldExecutionDefaults.push({
+          fieldName: field.name,
+          onCreate: { kind: "generator", id: resolution.generatorId },
+        });
+      }
+    }
 
     // @unique field attribute → unique index
     if (hasFieldAttribute(field, "unique")) {
@@ -591,7 +797,8 @@ function interpretModel(
     relations,
     relationsStorage,
     fksByTarget,
-    temporalUpdatedAtFields,
+    fieldExecutionDefaults,
+    autoIncrement,
   };
 }
 
@@ -753,16 +960,17 @@ export function interpretPslDocumentToIdbContract(
   for (const [modelName, interp] of interpretedByName) {
     stores[interp.storeName] = {
       keyPath: interp.keyPath,
+      ...(interp.autoIncrement ? { autoIncrement: true } : {}),
       ...(Object.keys(interp.indexes).length > 0 ? { indexes: interp.indexes } : {}),
     };
 
     roots[interp.storeName] = crossRef(modelName);
 
-    for (const fieldName of interp.temporalUpdatedAtFields) {
+    for (const fd of interp.fieldExecutionDefaults) {
       executionDefaults.push({
-        ref: { namespace: ns, table: interp.storeName, column: fieldName },
-        onCreate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
-        onUpdate: { kind: "generator", id: TIMESTAMP_NOW_GENERATOR_ID },
+        ref: { namespace: ns, table: interp.storeName, column: fd.fieldName },
+        ...(fd.onCreate ? { onCreate: fd.onCreate } : {}),
+        ...(fd.onUpdate ? { onUpdate: fd.onUpdate } : {}),
       });
     }
 

--- a/packages/prisma-next/family-idb/test/contract-psl.test.ts
+++ b/packages/prisma-next/family-idb/test/contract-psl.test.ts
@@ -965,4 +965,271 @@ describe("interpretPslDocumentToIdbContract", () => {
       expect(result.failure.diagnostics[0]!.code).toBe("IDB_TEMPORAL_UPDATED_AT_TAKES_NO_ARGS");
     });
   });
+
+  describe("@updatedAt (bare attribute)", () => {
+    it("resolves the same as temporal.updatedAt(): onCreate + onUpdate timestampNow", () => {
+      const result = interpret(`
+        model Post {
+          id        String   @id
+          title     String
+          updatedAt DateTime @updatedAt
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const model = result.value.domain.namespaces[NS]!.models["Post"] as unknown as TestContractModel;
+      expect(model.fields["updatedAt"]).toMatchObject({
+        nullable: false,
+        type: { kind: "scalar", codecId: "idb/date@1" },
+      });
+      expect(result.value.execution?.mutations.defaults).toEqual([
+        {
+          ref: { namespace: NS, table: "post", column: "updatedAt" },
+          onCreate: { kind: "generator", id: "timestampNow" },
+          onUpdate: { kind: "generator", id: "timestampNow" },
+        },
+      ]);
+    });
+
+    it("errors when used on the @id key field", () => {
+      const result = interpret(`
+        model Post {
+          id DateTime @id @updatedAt
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_TEMPORAL_UPDATED_AT_ON_KEY_FIELD");
+    });
+
+    it("errors on an optional field", () => {
+      const result = interpret(`
+        model Post {
+          id        String @id
+          updatedAt DateTime? @updatedAt
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_EXECUTION_DEFAULT_ON_OPTIONAL_FIELD");
+    });
+
+    it("errors on a non-DateTime field", () => {
+      const result = interpret(`
+        model Post {
+          id        String @id
+          updatedAt String @updatedAt
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_UPDATED_AT_NOT_DATETIME");
+    });
+
+    it("errors when combined with @default(...)", () => {
+      const result = interpret(`
+        model Post {
+          id        String @id
+          updatedAt DateTime @updatedAt @default(now())
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_UPDATED_AT_AND_DEFAULT_CONFLICT");
+    });
+  });
+
+  describe("@default(literal)", () => {
+    it("resolves boolean/number/string literals", () => {
+      const result = interpret(`
+        model Post {
+          id        String  @id
+          published Boolean @default(false)
+          views     Int     @default(0)
+          title     String  @default("untitled")
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.execution?.mutations.defaults).toEqual(
+        expect.arrayContaining([
+          {
+            ref: { namespace: NS, table: "post", column: "published" },
+            onCreate: { kind: "generator", id: "literal", params: { value: false } },
+          },
+          {
+            ref: { namespace: NS, table: "post", column: "views" },
+            onCreate: { kind: "generator", id: "literal", params: { value: 0 } },
+          },
+          {
+            ref: { namespace: NS, table: "post", column: "title" },
+            onCreate: { kind: "generator", id: "literal", params: { value: "untitled" } },
+          },
+        ])
+      );
+    });
+
+    it("allows a literal default on an optional field", () => {
+      const result = interpret(`
+        model Post {
+          id       String   @id
+          archived Boolean? @default(false)
+        }
+      `);
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("@default(now())", () => {
+    it("resolves to timestampNow, onCreate only (no onUpdate)", () => {
+      const result = interpret(`
+        model Post {
+          id        String   @id
+          createdAt DateTime @default(now())
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.execution?.mutations.defaults).toEqual([
+        {
+          ref: { namespace: NS, table: "post", column: "createdAt" },
+          onCreate: { kind: "generator", id: "timestampNow" },
+        },
+      ]);
+    });
+
+    it("errors on an optional field", () => {
+      const result = interpret(`
+        model Post {
+          id        String    @id
+          createdAt DateTime? @default(now())
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_EXECUTION_DEFAULT_ON_OPTIONAL_FIELD");
+    });
+  });
+
+  describe("@default(uuid())", () => {
+    it("resolves uuid() and uuid(4) to the uuidv4 generator", () => {
+      const result = interpret(`
+        model Post {
+          id  String @id
+          a   String @default(uuid())
+          b   String @default(uuid(4))
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const defaults = result.value.execution?.mutations.defaults;
+      expect(defaults).toEqual(
+        expect.arrayContaining([
+          { ref: { namespace: NS, table: "post", column: "a" }, onCreate: { kind: "generator", id: "uuidv4" } },
+          { ref: { namespace: NS, table: "post", column: "b" }, onCreate: { kind: "generator", id: "uuidv4" } },
+        ])
+      );
+    });
+
+    it("resolves uuid(7) to the uuidv7 generator", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(uuid(7))
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.execution?.mutations.defaults).toEqual([
+        { ref: { namespace: NS, table: "post", column: "id" }, onCreate: { kind: "generator", id: "uuidv7" } },
+      ]);
+    });
+
+    it("errors on an unsupported uuid version", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(uuid(9))
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_INVALID_DEFAULT_FUNCTION_ARGUMENT");
+    });
+  });
+
+  describe("@default(cuid())", () => {
+    it("resolves bare cuid() to the cuid2 generator", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(cuid())
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.execution?.mutations.defaults).toEqual([
+        { ref: { namespace: NS, table: "post", column: "id" }, onCreate: { kind: "generator", id: "cuid2" } },
+      ]);
+    });
+
+    it("errors on cuid(1) — no v1 generator available", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(cuid(1))
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_INVALID_DEFAULT_FUNCTION_ARGUMENT");
+    });
+  });
+
+  describe("@default(autoincrement())", () => {
+    it("sets IdbStoreDefinition.autoIncrement and adds no execution default", () => {
+      const result = interpret(`
+        model Post {
+          id Int @id @default(autoincrement())
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.storage.stores["post"]).toMatchObject({ autoIncrement: true });
+      expect(result.value.execution).toBeUndefined();
+    });
+
+    it("errors when used on a non-@id field", () => {
+      const result = interpret(`
+        model Post {
+          id    String @id
+          order Int    @default(autoincrement())
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_AUTOINCREMENT_NOT_ON_KEY_FIELD");
+    });
+
+    it("errors when the @id field is not Int", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(autoincrement())
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_AUTOINCREMENT_NOT_INT");
+    });
+  });
+
+  describe("@default(...) error cases", () => {
+    it("errors on an unknown default function", () => {
+      const result = interpret(`
+        model Post {
+          id String @id @default(dbgenerated("gen_random_uuid()"))
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_UNKNOWN_DEFAULT_FUNCTION");
+    });
+  });
 });

--- a/packages/prisma-next/family-idb/test/contract-psl.test.ts
+++ b/packages/prisma-next/family-idb/test/contract-psl.test.ts
@@ -864,4 +864,105 @@ describe("interpretPslDocumentToIdbContract", () => {
       expect(models["User"]!.relations).toHaveProperty("posts");
     });
   });
+
+  describe("temporal.updatedAt()", () => {
+    it("resolves the field as a DateTime and attaches an execution mutation default", () => {
+      const result = interpret(`
+        model Post {
+          id        String @id
+          title     String
+          updatedAt temporal.updatedAt()
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const model = result.value.domain.namespaces[NS]!.models["Post"] as unknown as TestContractModel;
+      expect(model.fields["updatedAt"]).toMatchObject({
+        nullable: false,
+        type: { kind: "scalar", codecId: "idb/date@1" },
+      });
+
+      expect(result.value.execution).toBeDefined();
+      expect(typeof result.value.execution?.executionHash).toBe("string");
+      expect(result.value.execution?.mutations.defaults).toEqual([
+        {
+          ref: { namespace: NS, table: "post", column: "updatedAt" },
+          onCreate: { kind: "generator", id: "timestampNow" },
+          onUpdate: { kind: "generator", id: "timestampNow" },
+        },
+      ]);
+    });
+
+    it("omits `execution` entirely when no model uses temporal.updatedAt()", () => {
+      const result = interpret(`model Post { id String @id }`);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.execution).toBeUndefined();
+    });
+
+    it("collects one execution default per model that uses it", () => {
+      const result = interpret(`
+        model User {
+          id        String @id
+          updatedAt temporal.updatedAt()
+        }
+        model Post {
+          id        String @id
+          updatedAt temporal.updatedAt()
+        }
+      `);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const tables = result.value.execution?.mutations.defaults.map((d) => d.ref.table).sort();
+      expect(tables).toEqual(["post", "user"]);
+    });
+
+    it("errors on an unrecognized type-constructor namespace", () => {
+      const result = interpret(`
+        model Post {
+          id  String @id
+          foo other.thing()
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_UNSUPPORTED_TYPE_CONSTRUCTOR");
+    });
+
+    it("errors on an unrecognized temporal.* constructor", () => {
+      const result = interpret(`
+        model Post {
+          id String @id
+          ts temporal.timestamp()
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_UNSUPPORTED_TYPE_CONSTRUCTOR");
+    });
+
+    it("errors when used on the @id key field", () => {
+      const result = interpret(`
+        model Post {
+          id temporal.updatedAt() @id
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_TEMPORAL_UPDATED_AT_ON_KEY_FIELD");
+    });
+
+    it("errors when the constructor call carries arguments", () => {
+      const result = interpret(`
+        model Post {
+          id        String @id
+          updatedAt temporal.updatedAt(3)
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_TEMPORAL_UPDATED_AT_TAKES_NO_ARGS");
+    });
+  });
 });

--- a/packages/prisma-next/family-idb/test/contract-psl.test.ts
+++ b/packages/prisma-next/family-idb/test/contract-psl.test.ts
@@ -1079,6 +1079,30 @@ describe("interpretPslDocumentToIdbContract", () => {
       `);
       expect(result.ok).toBe(true);
     });
+
+    it("errors on a string default for an Int field", () => {
+      const result = interpret(`
+        model Post {
+          id    String @id
+          views Int    @default("not a number")
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_INVALID_DEFAULT_VALUE");
+    });
+
+    it("errors on a numeric default for a Boolean field", () => {
+      const result = interpret(`
+        model Post {
+          id        String  @id
+          published Boolean @default(1)
+        }
+      `);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.diagnostics[0]!.code).toBe("IDB_INVALID_DEFAULT_VALUE");
+    });
   });
 
   describe("@default(now())", () => {

--- a/packages/prisma-next/target-idb/src/core/idb-contract-types.ts
+++ b/packages/prisma-next/target-idb/src/core/idb-contract-types.ts
@@ -44,14 +44,22 @@ export type IdbReferentialAction = "cascade" | "setNull" | "setDefault" | "restr
 /**
  * Mutation-default generator ids IDB recognizes in `contract.execution.mutations.defaults`.
  *
- * Only `"timestampNow"` exists today, backing `temporal.updatedAt()` PSL
- * fields (fires on both `onCreate` and `onUpdate`, matching the SQL family's
- * generator of the same name). Kept as a named union — rather than inlining
- * the string literal at each use site — so the id can't drift between the
- * PSL interpreter (which writes it) and the runtime mutation-defaults
- * resolver (which reads it).
+ * - `"timestampNow"` — `new Date()`. Backs `temporal.updatedAt()` and bare
+ *   `@updatedAt` (onCreate + onUpdate) and `@default(now())` (onCreate only).
+ * - `"literal"` — echoes `params.value` verbatim. Backs `@default(<literal>)`.
+ *   IDB has no storage-plane default slot (no server to render one), so even
+ *   a literal default has to be produced by this same execution-plane
+ *   mechanism.
+ * - `"uuidv4"` / `"uuidv7"` / `"cuid2"` — backed by `@prisma-next/ids`
+ *   (the same shared framework ID-generation package the SQL family's own
+ *   presets use). Back `@default(uuid())` / `@default(uuid(7))` / `@default(cuid())`.
+ *
+ * Kept as a named union — rather than inlining string literals at each use
+ * site — so an id can't drift between the PSL interpreter (which writes it)
+ * and the runtime mutation-defaults resolver (which reads it, exhaustively
+ * switching over this type).
  */
-export type IdbMutationDefaultGeneratorId = "timestampNow";
+export type IdbMutationDefaultGeneratorId = "timestampNow" | "literal" | "uuidv4" | "uuidv7" | "cuid2";
 
 /** Per-relation storage metadata attached to {@link IdbModelStorage}. */
 export type IdbRelationStorage = {

--- a/packages/prisma-next/target-idb/src/core/idb-contract-types.ts
+++ b/packages/prisma-next/target-idb/src/core/idb-contract-types.ts
@@ -41,6 +41,18 @@ export type IdbIndexDefinition = {
 /** Referential action executed on child rows when a parent row is deleted. */
 export type IdbReferentialAction = "cascade" | "setNull" | "setDefault" | "restrict" | "noAction";
 
+/**
+ * Mutation-default generator ids IDB recognizes in `contract.execution.mutations.defaults`.
+ *
+ * Only `"timestampNow"` exists today, backing `temporal.updatedAt()` PSL
+ * fields (fires on both `onCreate` and `onUpdate`, matching the SQL family's
+ * generator of the same name). Kept as a named union — rather than inlining
+ * the string literal at each use site — so the id can't drift between the
+ * PSL interpreter (which writes it) and the runtime mutation-defaults
+ * resolver (which reads it).
+ */
+export type IdbMutationDefaultGeneratorId = "timestampNow";
+
 /** Per-relation storage metadata attached to {@link IdbModelStorage}. */
 export type IdbRelationStorage = {
   readonly onDelete?: IdbReferentialAction;

--- a/packages/prisma-next/target-idb/src/exports/pack.ts
+++ b/packages/prisma-next/target-idb/src/exports/pack.ts
@@ -6,6 +6,7 @@ export type {
   IdbContractWithTypeMaps,
   IdbIndexDefinition,
   IdbModelStorage,
+  IdbMutationDefaultGeneratorId,
   IdbReferentialAction,
   IdbRelationStorage,
   IdbStoreDefinition,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         version: 2.1.1
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 1.7.2(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -144,7 +144,7 @@ importers:
         version: link:../../packages/generator
       '@prisma/client':
         specifier: ^7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -183,16 +183,16 @@ importers:
         version: 3.1.18
       fumadocs-core:
         specifier: ^16.14.2
-        version: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        version: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.2.2
-        version: 15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
+        version: 15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
       fumadocs-ui:
         specifier: ^16.14.2
-        version: 16.14.2(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
+        version: 16.14.2(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       geist:
         specifier: ^1.7.2
-        version: 1.7.2(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 1.7.2(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       lucide-react:
         specifier: ^1.30.0
         version: 1.30.0(react@19.2.8)
@@ -256,7 +256,7 @@ importers:
         version: 6.1.38(svelte@5.56.8(@typescript-eslint/types@8.66.0))
       better-auth:
         specifier: ^1.6.26
-        version: 1.6.26(deec89c0eeccb50c0a70560217f22e83)
+        version: 1.6.26(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(mysql2@3.15.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -287,7 +287,7 @@ importers:
         version: 7.9.1
       '@prisma/client':
         specifier: ^7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       '@sveltejs/adapter-vercel':
         specifier: ^6.3.4
         version: 6.3.4(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(rollup@2.80.0)
@@ -422,7 +422,7 @@ importers:
         version: 0.16.0(typanion@3.14.0)(typescript@6.0.3)
       better-auth:
         specifier: ^1.6.26
-        version: 1.6.26(deec89c0eeccb50c0a70560217f22e83)
+        version: 1.6.26(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(mysql2@3.15.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -638,7 +638,7 @@ importers:
         version: link:../../packages/generator
       '@prisma/client':
         specifier: ^7.9.1
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
         version: 7.0.1(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))
@@ -719,7 +719,7 @@ importers:
         version: 3.3.0
       '@prisma/client':
         specifier: ^6.0.0 || ^7.0.0
-        version: 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       '@prisma/generator-helper':
         specifier: ^7.9.1
         version: 7.9.1
@@ -789,6 +789,9 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(typescript@6.0.3)
       '@prisma-next/framework-components':
+        specifier: ^0.16.0
+        version: 0.16.0(typescript@6.0.3)
+      '@prisma-next/ids':
         specifier: ^0.16.0
         version: 0.16.0(typescript@6.0.3)
       '@prisma-next/migration-tools':
@@ -10761,12 +10764,12 @@ snapshots:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))':
+  '@better-auth/prisma-adapter@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))':
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       prisma: 7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3)
 
   '@better-auth/telemetry@1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
@@ -12050,7 +12053,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.9.1': {}
 
-  '@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)':
+  '@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.9.1
     optionalDependencies:
@@ -13924,14 +13927,14 @@ snapshots:
 
   basic-ftp@5.3.1: {}
 
-  better-auth@1.6.26(deec89c0eeccb50c0a70560217f22e83):
+  better-auth@1.6.26(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(@sveltejs/kit@2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(mysql2@3.15.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.22.0)(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))):
     dependencies:
       '@better-auth/core': 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2)
       '@better-auth/drizzle-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
       '@better-auth/kysely-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)
       '@better-auth/memory-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))
+      '@better-auth/prisma-adapter': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))
       '@better-auth/telemetry': 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.5)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -13944,7 +13947,7 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.4.3
     optionalDependencies:
-      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.9.1(prisma@7.9.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(typescript@6.0.3)
       '@sveltejs/kit': 2.70.2(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.8(@typescript-eslint/types@8.66.0))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)))(svelte@5.56.8(@typescript-eslint/types@8.66.0))(typescript@6.0.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0))
       mysql2: 3.15.3
       next: 16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -15614,7 +15617,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3):
+  fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3):
     dependencies:
       estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
@@ -15648,14 +15651,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)):
+  fumadocs-mdx@15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.11)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      fumadocs-core: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       github-slugger: 2.0.0
       magic-string: 1.1.0
       mdast-util-mdx: 3.0.0
@@ -15681,7 +15684,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.14.2(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
+  fumadocs-ui@16.14.2(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
@@ -15697,7 +15700,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       cnfast: 0.1.0
-      fumadocs-core: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      fumadocs-core: 16.14.2(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.30.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       lucide-react: 1.30.0(react@19.2.8)
       motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -15735,7 +15738,7 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
-  geist@1.7.2(next@16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
+  geist@1.7.2(next@16.3.0(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
       next: 16.3.0(@babel/core@7.29.7)(@playwright/test@1.62.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 


### PR DESCRIPTION
## Description

This update enhances the handling of mutation defaults by introducing new generators and type definitions, including support for the `temporal.updatedAt()` field. It also fixes a bug in the SQL autoincrement implementation.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] create-input.test.ts > makes a field with an onCreate execution default optional, alongside the key
- [ ] create-input.test.ts > still requires a field with no execution default



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic IndexedDB defaults for timestamps, literals, UUIDs, and CUIDs during creates and updates.
  * Added support for auto-incrementing integer identifiers and `@updatedAt` fields.
  * Create inputs can omit fields populated automatically.
  * Added validation for unsupported or incompatible default definitions.

* **Bug Fixes**
  * Applied defaults consistently across nested mutations, upserts, bulk creates, and updates.
  * Updated the example migration to use auto-incrementing identifiers.

* **Tests**
  * Added coverage for default generation, validation, input typing, and mutation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->